### PR TITLE
Lexing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## Unreleased
+### Fixed
+- Fixed a bug in the lexer that would cause it to crash if reading a slash before a quote, such as in the function name `"\\"`.
+- Fixed a bug in the lexer where it would return the escaped `\\` rather than the actual value `\` in strings.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,4 @@ If you experience any problems on other versions or OSes, please raise an issue.
 A few request-types related to tt-terms have not been implemented yet, because I don’t understand what they’re supposed to do.
 
 ## Known Issues
-There’s one bug in the lexer that I know of, it’s on the to do list to fix. At the moment it chokes on the string ` "Prelude.List.\\\\"`.
-
 The handling for unexpected errors could use a bit of work. For example, in Idris 1.3.2, you can cause the IDE to crash by passing in a line number that doesn’t exist, and there’s nothing at the moment to restart the IDE if it dies unexpectedly.

--- a/src/client.ts
+++ b/src/client.ts
@@ -249,7 +249,7 @@ export class IdrisClient {
   }
 
   /**
-   * Returns a reply containing a string represetning a new with-rule pattern match template.
+   * Returns a reply containing a string representing a new with-rule pattern match template.
    * Always successful — simply returns the result of wrapping the `name` argument
    * in a with-clause.
    */
@@ -261,7 +261,7 @@ export class IdrisClient {
 
   /**
    * Returns a reply containing a list of metavariable descriptions. Each has the name
-   * and type of the metavariable, with metadata, as well as a list of descriptions
+   * and type of the metavariable, with metadata for the type, as well as a list of descriptions
    * for other variables in the metavariable’s scope.
    * Always successful — it is an empty list if no metavariables are found.
    */

--- a/test/parser/case-split.test.ts
+++ b/test/parser/case-split.test.ts
@@ -27,18 +27,15 @@ describe("Parsing :case-split reply", () => {
     assert.deepEqual(parsed, expected)
   })
 
-  // Using String.raw`...` to get around unexpected escaping behaviour. Sigh.
-  // So `\"` becomes `"`. But `\\"` becomes...`\\"`. Obviously.
-  // With String.raw I can just copy-and-paste the text from STDOUT.
   it("can parse a failure sexp.", () => {
-    const sexp = String.raw`(:return (:error "Elaborating {__infer_0} arg {ival_0}: Internal error: \"Unelaboratable syntactic form (Example.plusTwo : (n : Nat) ->\\nNat)\"") 2)`
+    const sexp = `(:return (:error "Elaborating {__infer_0} arg {ival_0}: Internal error: \\"Unelaboratable syntactic form (Example.plusTwo : (n : Nat) ->\nNat)\\"") 2)`
     const payload: S_Exp.CaseSplitErr = [
       ":error",
-      String.raw`Elaborating {__infer_0} arg {ival_0}: Internal error: \"Unelaboratable syntactic form (Example.plusTwo : (n : Nat) ->\\nNat)\"`,
+      `Elaborating {__infer_0} arg {ival_0}: Internal error: "Unelaboratable syntactic form (Example.plusTwo : (n : Nat) ->\nNat)"`,
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.CaseSplit = {
-      err: String.raw`Elaborating {__infer_0} arg {ival_0}: Internal error: \"Unelaboratable syntactic form (Example.plusTwo : (n : Nat) ->\\nNat)\"`,
+      err: `Elaborating {__infer_0} arg {ival_0}: Internal error: "Unelaboratable syntactic form (Example.plusTwo : (n : Nat) ->\nNat)"`,
       id: 2,
       type: ":return",
     }

--- a/test/parser/interpret.test.ts
+++ b/test/parser/interpret.test.ts
@@ -300,15 +300,15 @@ describe("Parsing :interpret reply", () => {
   })
 
   it("can parse a failure sexp without metadata.", () => {
-    const sexp = String.raw`(:return (:error "(input):1:1:\n  |\n1 | -----\n  | ^^^^^\nunexpected \"-----\"\nexpecting ':', dependent type signature, or end of input\n") 3)`
+    const sexp = `(:return (:error "(input):1:1:\n  |\n1 | -----\n  | ^^^^^\nunexpected \\"-----\\"\nexpecting ':', dependent type signature, or end of input\n") 3)`
     const payload: S_Exp.InterpretErr = [
       ":error",
-      String.raw`(input):1:1:\n  |\n1 | -----\n  | ^^^^^\nunexpected \"-----\"\nexpecting ':', dependent type signature, or end of input\n`,
+      `(input):1:1:\n  |\n1 | -----\n  | ^^^^^\nunexpected "-----"\nexpecting ':', dependent type signature, or end of input\n`,
     ]
     const rootExpr: RootExpr = [":return", payload, 3]
     const expected: FinalReply.Interpret = {
       err: {
-        message: String.raw`(input):1:1:\n  |\n1 | -----\n  | ^^^^^\nunexpected \"-----\"\nexpecting ':', dependent type signature, or end of input\n`,
+        message: `(input):1:1:\n  |\n1 | -----\n  | ^^^^^\nunexpected "-----"\nexpecting ':', dependent type signature, or end of input\n`,
         metadata: [],
       },
       id: 3,


### PR DESCRIPTION
- Fixed a bug in the lexer that would cause it to crash if reading a slash before a quote, such as in the function name `"\\"`.
- Fixed a bug in the lexer where it would return the escaped `\\` rather than the actual value `\` in strings.
