### PR TITLE
Sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## Unreleased
+### Added
+- Support for connecting to an Idris process over sockets.
+
+### Changed
+- Breaking: IdrisClient constructor now accepts an input stream and an output stream, and no longer manages the Idris process.
+
 ### Fixed
 - Fixed a bug in the lexer that would cause it to crash if reading a slash before a quote, such as in the function name `"\\"`.
 - Fixed a bug in the lexer where it would return the escaped `\\` rather than the actual value `\` in strings.

--- a/examples/socket.ts
+++ b/examples/socket.ts
@@ -1,0 +1,22 @@
+import { spawn } from "child_process"
+import { IdrisClient } from "idris-ide-client"
+import { Socket } from "net"
+
+const idrisProc = spawn("idris", ["--ide-mode-socket"])
+
+// When you start Idris in socket IDE mode, it prints the socket port.
+const portProm: Promise<number> = new Promise((res) =>
+  idrisProc.stdout.once("data", (chunk: Buffer) =>
+    res(parseInt(chunk.toString("utf8")))
+  )
+)
+const socket = new Socket({ readable: true, writable: true })
+
+const port = await portProm
+socket.connect({ port })
+
+const client = new IdrisClient(socket, socket)
+client
+  .interpret("2 + 2")
+  .then(console.log)
+  .then(() => socket.destroy())

--- a/examples/stdio.ts
+++ b/examples/stdio.ts
@@ -1,0 +1,10 @@
+import { spawn } from "child_process"
+import { IdrisClient } from "idris-ide-client"
+
+const idrisProc = spawn("idris", ["--ide-mode"])
+const client = new IdrisClient(idrisProc.stdin, idrisProc.stdout)
+
+client
+  .interpret("2 + 2")
+  .then(console.log)
+  .then(() => idrisProc.kill())

--- a/package.json
+++ b/package.json
@@ -10,17 +10,17 @@
     "type": "git",
     "url": "https://github.com/meraymond2/idris-ide-client"
   },
-  "main": "./build/src/index.js",
-  "types": "./build/src/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
   "files": [
     "build"
   ],
   "scripts": {
-    "build": "tsc -p ./ && rm -r build/test",
+    "build": "tsc -p .",
     "eslint": "eslint src --ext ts",
     "lint": "tsc --noEmit && prettier --check --write 'src/**/*.ts' && eslint src --ext .ts --fix",
     "prepublishOnly": "npm run build",
-    "start": "npm run build && node build/src/index.js",
+    "start": "npm run build && node build/index.js",
     "test": "npx mocha --recursive --require ts-node/register --extensions ts 'test/**/*.ts'",
     "watch": "tsc -watch -p ./"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,5 @@ import { InfoReply, FinalReply, OutputReply, Reply } from "./reply"
 import { Request } from "./request"
 
 export { IdrisClient, InfoReply, FinalReply, OutputReply, Reply, Request }
+
+console.log("hey")

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,3 @@ import { InfoReply, FinalReply, OutputReply, Reply } from "./reply"
 import { Request } from "./request"
 
 export { IdrisClient, InfoReply, FinalReply, OutputReply, Reply, Request }
-
-console.log("hey")

--- a/test/client/client.test.ts
+++ b/test/client/client.test.ts
@@ -1,15 +1,20 @@
 import { assert } from "chai"
 import { IdrisClient } from "../../src/client"
 import * as expected from "./expected"
+import { spawn, ChildProcess } from "child_process"
 
 // These tests are order dependent, which is ugly, but the alternative is
 // stopping and re-starting the client between each one, which would add seconds
 // to each test. If it becomes an issue in the future, it can be changed.
 describe("Running the client commands", () => {
   let ic: IdrisClient
+  let proc: ChildProcess
 
   before(async () => {
-    ic = new IdrisClient()
+    proc = spawn("idris", ["--ide-mode"])
+    if (proc.stdin && proc.stdout) {
+      ic = new IdrisClient(proc.stdin, proc.stdout)
+    }
   })
 
   it("returns the expected result for :load-file", async () => {
@@ -111,6 +116,6 @@ describe("Running the client commands", () => {
   })
 
   after(async () => {
-    await ic.close()
+    proc.kill()
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
     "noUnusedParameters": true /* Report errors on unused parameters. */
   },
-  "include": ["src", "test"],
+  "include": ["src"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Adds support for talking to [Idris over a socket](https://github.com/meraymond2/idris-ide-client/issues/2).

I'm still curious about the idea of extending this to web-sockets, so that this library could be used in a browser application with a non-TS backend. Browser-native `WebSocket`s have a different API, but there are libraries to make them act like Node streams. 