### PR TITLE
Return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+### Added
+### Changed
+- Breaking: `ok` in FinalReply is now a Boolean discriminator.
+
+### Fixed
+
 ## v0.1.2
 ### Added
 - Support for connecting to an Idris process over sockets.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ await client.loadFile("test/resources/test.idr")
 const reply = await client.typeOf("n")
 
 // Do something with the reply
-if ("ok" in reply) {
-  console.log(reply.ok.type) // => "n : Nat"
+if (reply.ok) {
+  console.log(reply.typeOf) // => "n : Nat"
 } else {
   console.warn(reply.err)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { IdrisClient } from "./client"
-import {
+export { IdrisClient } from "./client"
+export {
   InfoReply,
   FinalReply,
   HolePremise,
@@ -9,19 +9,5 @@ import {
   Reply,
   SourceMetadata,
 } from "./reply"
-import { Request } from "./request"
-import { Decor } from "./s-exps"
-
-export {
-  Decor,
-  FinalReply,
-  IdrisClient,
-  InfoReply,
-  HolePremise,
-  MessageMetadata,
-  Metavariable,
-  OutputReply,
-  Reply,
-  Request,
-  SourceMetadata,
-}
+export { Request } from "./request"
+export { Decor } from "./s-exps"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,27 @@
 import { IdrisClient } from "./client"
-import { InfoReply, FinalReply, OutputReply, Reply } from "./reply"
+import {
+  InfoReply,
+  FinalReply,
+  HolePremise,
+  Metavariable,
+  MessageMetadata,
+  OutputReply,
+  Reply,
+  SourceMetadata,
+} from "./reply"
 import { Request } from "./request"
+import { Decor } from "./s-exps"
 
-export { IdrisClient, InfoReply, FinalReply, OutputReply, Reply, Request }
+export {
+  Decor,
+  FinalReply,
+  IdrisClient,
+  InfoReply,
+  HolePremise,
+  MessageMetadata,
+  Metavariable,
+  OutputReply,
+  Reply,
+  Request,
+  SourceMetadata,
+}

--- a/src/parser/reply-parser.ts
+++ b/src/parser/reply-parser.ts
@@ -226,8 +226,9 @@ const intoFinalReplyAddClause = (
 ): FinalReply.AddClause => {
   const [_ok, initialClause] = payload
   return {
-    ok: initialClause,
+    initialClause,
     id,
+    ok: true,
     type: ":return",
   }
 }
@@ -236,10 +237,11 @@ const intoFinalReplyAddMissing = (
   payload: S_Exp.AddMissing,
   id: number
 ): FinalReply.AddMissing => {
-  const [_ok, missingCases] = payload
+  const [_ok, missingClauses] = payload
   return {
-    ok: missingCases,
     id,
+    ok: true,
+    missingClauses,
     type: ":return",
   }
 }
@@ -251,8 +253,10 @@ const intoFinalReplyApropos = (
   if (S_Exp.isOkApropos(payload)) {
     const [_ok, apropos, metadata] = payload
     return {
-      ok: { docs: apropos, metadata: intoMessageMetadata(metadata) },
+      docs: apropos,
+      metadata: intoMessageMetadata(metadata),
       id,
+      ok: true,
       type: ":return",
     }
   } else {
@@ -260,6 +264,7 @@ const intoFinalReplyApropos = (
     return {
       err: msg,
       id,
+      ok: false,
       type: ":return",
     }
   }
@@ -272,8 +277,10 @@ const intoFinalReplyBrowseNamespace = (
   if (S_Exp.isOkBrowseNamespace(payload)) {
     const [_ok, [subModules, decls]] = payload
     return {
-      ok: { subModules, declarations: decls.map(formatDecl) },
+      declarations: decls.map(formatDecl),
       id,
+      ok: true,
+      subModules,
       type: ":return",
     }
   } else {
@@ -281,6 +288,7 @@ const intoFinalReplyBrowseNamespace = (
     return {
       err: msg,
       id,
+      ok: false,
       type: ":return",
     }
   }
@@ -293,17 +301,18 @@ const intoFinalReplyCallsWho = (
   if (payload[1].length > 0) {
     const [_ok, [[decl, refs]]] = payload
     return {
-      ok: {
-        caller: formatDecl(decl),
-        references: refs.map(formatDecl),
-      },
+      caller: formatDecl(decl),
       id,
+      ok: true,
+      references: refs.map(formatDecl),
       type: ":return",
     }
   } else {
     return {
-      ok: { caller: null, references: [] },
+      caller: null,
       id,
+      ok: true,
+      references: [],
       type: ":return",
     }
   }
@@ -314,10 +323,11 @@ const intoFinalReplyCaseSplit = (
   id: number
 ): FinalReply.CaseSplit => {
   if (S_Exp.isOkCaseSplit(payload)) {
-    const [_ok, caseStmts] = payload
+    const [_ok, caseClause] = payload
     return {
-      ok: caseStmts,
+      caseClause,
       id,
+      ok: true,
       type: ":return",
     }
   } else {
@@ -325,6 +335,7 @@ const intoFinalReplyCaseSplit = (
     return {
       err: msg,
       id,
+      ok: false,
       type: ":return",
     }
   }
@@ -337,8 +348,10 @@ const intoFinalReplyDocsFor = (
   if (S_Exp.isOkDocsFor(payload)) {
     const [_ok, docs, metadata] = payload
     return {
-      ok: { docs, metadata: intoMessageMetadata(metadata) },
+      docs,
       id,
+      metadata: intoMessageMetadata(metadata),
+      ok: true,
       type: ":return",
     }
   } else {
@@ -346,6 +359,7 @@ const intoFinalReplyDocsFor = (
     return {
       err: msg,
       id,
+      ok: false,
       type: ":return",
     }
   }
@@ -358,18 +372,19 @@ const intoFinalReplyInterpret = (
   if (S_Exp.isOkInterpret(payload)) {
     const [_ok, result, metadata] = payload
     return {
-      ok: {
-        result,
-        metadata: intoMessageMetadata(metadata),
-      },
       id,
+      ok: true,
+      metadata: intoMessageMetadata(metadata),
+      result,
       type: ":return",
     }
   } else {
-    const [_err, message, metadata] = payload
+    const [_err, msg, metadata] = payload
     return {
-      err: { message, metadata: intoMessageMetadata(metadata || []) },
+      err: msg,
       id,
+      metadata: intoMessageMetadata(metadata || []),
+      ok: false,
       type: ":return",
     }
   }
@@ -381,8 +396,8 @@ const intoFinalReplyLoadFile = (
 ): FinalReply.LoadFile => {
   if (S_Exp.isOkLoadFile(payload)) {
     return {
-      ok: null,
       id,
+      ok: true,
       type: ":return",
     }
   } else {
@@ -390,6 +405,7 @@ const intoFinalReplyLoadFile = (
     return {
       err: msg,
       id,
+      ok: false,
       type: ":return",
     }
   }
@@ -401,8 +417,9 @@ const intoFinalReplyMakeCase = (
 ): FinalReply.MakeCase => {
   const [_ok, caseClause] = payload
   return {
-    ok: caseClause,
+    caseClause,
     id,
+    ok: true,
     type: ":return",
   }
 }
@@ -417,11 +434,10 @@ const intoFinalReplyMakeLemma = (
       [_metavariableLemma, [_replace, metavariable], [_def_type, declaration]],
     ] = payload
     return {
-      ok: {
-        declaration,
-        metavariable,
-      },
+      declaration,
       id,
+      ok: true,
+      metavariable,
       type: ":return",
     }
   } else {
@@ -429,6 +445,7 @@ const intoFinalReplyMakeLemma = (
     return {
       err: msg,
       id,
+      ok: false,
       type: ":return",
     }
   }
@@ -440,8 +457,9 @@ const intoFinalReplyMakeWith = (
 ): FinalReply.MakeWith => {
   const [_ok, withClause] = payload
   return {
-    ok: withClause,
+    withClause,
     id,
+    ok: true,
     type: ":return",
   }
 }
@@ -450,23 +468,23 @@ const intoFinalReplyMetavariables = (
   payload: S_Exp.Metavariables,
   id: number
 ): FinalReply.Metavariables => {
-  const [_ok, metavariables] = payload
-  const metavars = metavariables.map(
-    ([name, varsInScope, [type, metadata]]) => {
+  const [_ok, metavars] = payload
+  const metavariables = metavars.map(
+    ([name, holePremises, [type, metadata]]) => {
       const metavariable = {
         name,
         type,
         metadata: intoMessageMetadata(metadata),
       }
-      const scope = varsInScope.map(([name, type, metadata]) => ({
+      const premises = holePremises.map(([name, type, metadata]) => ({
         name,
         type,
         metadata: intoMessageMetadata(metadata),
       }))
-      return { metavariable, scope }
+      return { metavariable, premises }
     }
   )
-  return { ok: metavars, id, type: ":return" }
+  return { id, ok: true, metavariables, type: ":return" }
 }
 
 const intoFinalReplyPrintDefinition = (
@@ -476,8 +494,10 @@ const intoFinalReplyPrintDefinition = (
   if (S_Exp.isOkPrintDefinition(payload)) {
     const [_ok, definition, metadata] = payload
     return {
-      ok: { definition, metadata: intoMessageMetadata(metadata) },
+      definition,
       id,
+      metadata: intoMessageMetadata(metadata),
+      ok: true,
       type: ":return",
     }
   } else {
@@ -485,6 +505,7 @@ const intoFinalReplyPrintDefinition = (
     return {
       err: msg,
       id,
+      ok: false,
       type: ":return",
     }
   }
@@ -496,8 +517,9 @@ const intoFinalReplyProofSearch = (
 ): FinalReply.ProofSearch => {
   const [_ok, solution] = payload
   return {
-    ok: solution,
     id,
+    ok: true,
+    solution,
     type: ":return",
   }
 }
@@ -508,8 +530,9 @@ const intoFinalReplyReplCompletions = (
 ): FinalReply.ReplCompletions => {
   const [_ok, [completions, _x]] = payload // x is always ""?
   return {
-    ok: completions,
+    completions,
     id,
+    ok: true,
     type: ":return",
   }
 }
@@ -519,17 +542,20 @@ const intoFinalReplyTypeOf = (
   id: number
 ): FinalReply.TypeOf => {
   if (S_Exp.isOkTypeOf(payload)) {
-    const [_ok, type, metadata] = payload
+    const [_ok, typeOf, metadata] = payload
     return {
-      ok: { type, metadata: intoMessageMetadata(metadata) },
       id,
+      ok: true,
+      metadata: intoMessageMetadata(metadata),
       type: ":return",
+      typeOf,
     }
   } else {
     const [_err, msg] = payload
     return {
       err: msg,
       id,
+      ok: false,
       type: ":return",
     }
   }
@@ -541,13 +567,12 @@ const intoFinalReplyVersion = (
 ): FinalReply.Version => {
   const [_ok, [[major, minor, patch], tags]] = payload
   return {
-    ok: {
-      major,
-      minor,
-      patch,
-      tags,
-    },
     id,
+    major,
+    minor,
+    ok: true,
+    patch,
+    tags,
     type: ":return",
   }
 }
@@ -559,17 +584,18 @@ const intoFinalReplyWhoCalls = (
   if (payload[1].length > 0) {
     const [_ok, [[decl, refs]]] = payload
     return {
-      ok: {
-        callee: formatDecl(decl),
-        references: refs.map(formatDecl),
-      },
+      callee: formatDecl(decl),
       id,
+      ok: true,
+      references: refs.map(formatDecl),
       type: ":return",
     }
   } else {
     return {
-      ok: { callee: null, references: [] },
+      callee: null,
       id,
+      ok: true,
+      references: [],
       type: ":return",
     }
   }

--- a/src/reply.ts
+++ b/src/reply.ts
@@ -35,6 +35,36 @@ export interface SourceMetadata {
   metadata: MetaDetails
 }
 
+export interface FileWarning {
+  end: Position
+  filename: string
+  metadata: Array<MessageMetadata>
+  start: Position
+  warning: string
+}
+
+export interface Declaration {
+  name: string
+  metadata: Array<MessageMetadata>
+}
+
+export interface Variable {
+  name: string
+  type: string
+  metadata: Array<MessageMetadata>
+}
+
+export interface HolePremise {
+  name: string
+  type: string
+  metadata: Array<MessageMetadata>
+}
+
+export interface Metavariable {
+  metavariable: Variable
+  scope: Array<HolePremise>
+}
+
 export namespace InfoReply {
   export interface SetPrompt extends BaseReply {
     path: string
@@ -49,13 +79,7 @@ export namespace InfoReply {
   }
 
   export interface Warning extends BaseReply {
-    err: {
-      end: Position
-      filename: string
-      metadata: MessageMetadata[]
-      start: Position
-      warning: string
-    }
+    err: FileWarning
     id: number
     type: ":warning"
   }
@@ -68,7 +92,7 @@ export namespace InfoReply {
 }
 
 export interface OutputReply extends BaseReply {
-  ok: SourceMetadata[]
+  ok: Array<SourceMetadata>
   id: number
   type: ":output"
 }
@@ -79,156 +103,141 @@ export namespace FinalReply {
     reply.type === ":return"
 
   export type AddClause = {
-    ok: string
+    initialClause: string
     id: number
+    ok: true
     type: ":return"
   }
 
   export type AddMissing = {
-    ok: string
     id: number
+    ok: true
+    missingClause: string
     type: ":return"
   }
 
   export type Apropos =
     | {
-        ok: {
-          docs: string
-          metadata: MessageMetadata[]
-        }
+        docs: string
         id: number
+        metadata: Array<MessageMetadata>
+        ok: true
         type: ":return"
       }
-    | { err: string; id: number; type: ":return" }
+    | { err: string; id: number; ok: false; type: ":return" }
 
   export type BrowseNamespace =
     | {
-        ok: {
-          declarations: {
-            name: string
-            metadata: MessageMetadata[]
-          }[]
-          subModules: string[]
-        }
+        declarations: Array<Declaration>
         id: number
+        ok: true
+        subModules: string[]
         type: ":return"
       }
-    | { err: string; id: number; type: ":return" }
+    | { err: string; id: number; ok: false; type: ":return" }
 
   /**
    * Caller is null only when it is not found.
    */
   export type CallsWho = {
-    ok: {
-      caller: {
-        name: string
-        metadata: MessageMetadata[]
-      } | null
-      references: {
-        name: string
-        metadata: MessageMetadata[]
-      }[]
-    }
+    caller: Declaration | null
     id: number
+    ok: true
+    references: Array<Declaration>
     type: ":return"
   }
 
   export type CaseSplit =
     | {
-        ok: string
+        caseClause: string
         id: number
+        ok: true
         type: ":return"
       }
-    | { err: string; id: number; type: ":return" }
+    | { err: string; id: number; ok: false; type: ":return" }
 
   export type DocsFor =
     | {
-        ok: {
-          docs: string
-          metadata: MessageMetadata[]
-        }
+        docs: string
+        metadata: Array<MessageMetadata>
         id: number
+        ok: true
         type: ":return"
       }
-    | { err: string; id: number; type: ":return" }
+    | { err: string; id: number; ok: false; type: ":return" }
 
   /**
    * If part of the input can be interpreted, it will be an error, but with metadata.
    */
   export type Interpret =
     | {
-        ok: { result: string; metadata: MessageMetadata[] }
         id: number
+        ok: true
+        metadata: Array<MessageMetadata>
+        result: string
         type: ":return"
       }
     | {
-        err: {
-          message: string
-          metadata: MessageMetadata[]
-        }
+        err: string
+        metadata: MessageMetadata[]
         id: number
+        ok: false
         type: ":return"
       }
 
   export type LoadFile =
     | {
-        ok: null
         id: number
+        ok: true
         type: ":return"
       }
-    | { err: string; id: number; type: ":return" }
+    | { err: string; id: number; ok: false; type: ":return" }
 
   export type MakeCase = {
-    ok: string
+    caseClause: string
     id: number
+    ok: true
     type: ":return"
   }
 
   export type MakeLemma =
     | {
-        ok: {
-          declaration: string
-          metavariable: string
-        }
+        declaration: string
+        metavariable: string
         id: number
+        ok: true
         type: ":return"
       }
-    | { err: string; id: number; type: ":return" }
+    | { err: string; id: number; ok: false; type: ":return" }
 
   export type MakeWith = {
-    ok: string
     id: number
+    ok: true
     type: ":return"
+    withClause: string
   }
 
   export type Metavariables = {
-    ok: {
-      metavariable: {
-        name: string
-        type: string
-        metadata: MessageMetadata[]
-      }
-      scope: {
-        name: string
-        type: string
-        metadata: MessageMetadata[]
-      }[]
-    }[]
     id: number
+    metavariables: Array<Metavariable>
+    ok: true
     type: ":return"
   }
 
   export type PrintDefinition =
     | {
-        ok: { definition: string; metadata: MessageMetadata[] }
+        definition: string
         id: number
+        metadata: Array<MessageMetadata>
+        ok: true
         type: ":return"
       }
-    | { err: string; id: number; type: ":return" }
+    | { err: string; id: number; ok: false; type: ":return" }
 
   export type ProofSearch = {
-    ok: string
+    result: string
     id: number
+    ok: true
     type: ":return"
   }
 
@@ -236,46 +245,37 @@ export namespace FinalReply {
    * This reply omits an additional element that seems to always be an empty string.
    */
   export type ReplCompletions = {
-    ok: string[]
+    completions: Array<string>
     id: number
+    ok: true
     type: ":return"
   }
 
   export type TypeOf =
     | {
-        ok: {
-          type: string
-          metadata: MessageMetadata[]
-        }
         id: number
+        ok: true
+        metadata: Array<MessageMetadata>
+        typeOf: string
         type: ":return"
       }
-    | { err: string; id: number; type: ":return" }
+    | { err: string; id: number; ok: false; type: ":return" }
 
   export type Version = {
-    ok: {
-      major: number
-      minor: number
-      patch: number
-      tags: string[]
-    }
     id: number
+    minor: number
+    major: number
+    ok: true
+    patch: number
+    tags: Array<string>
     type: ":return"
   }
 
   export type WhoCalls = {
-    ok: {
-      callee: {
-        name: string
-        metadata: MessageMetadata[]
-      } | null
-      references: {
-        name: string
-        metadata: MessageMetadata[]
-      }[]
-    }
-
+    callee: Declaration | null
+    references: Array<Declaration>
     id: number
+    ok: true
     type: ":return"
   }
 }

--- a/src/reply.ts
+++ b/src/reply.ts
@@ -62,7 +62,7 @@ export interface HolePremise {
 
 export interface Metavariable {
   metavariable: Variable
-  scope: Array<HolePremise>
+  premises: Array<HolePremise>
 }
 
 export namespace InfoReply {
@@ -112,7 +112,7 @@ export namespace FinalReply {
   export type AddMissing = {
     id: number
     ok: true
-    missingClause: string
+    missingClauses: string
     type: ":return"
   }
 
@@ -235,9 +235,9 @@ export namespace FinalReply {
     | { err: string; id: number; ok: false; type: ":return" }
 
   export type ProofSearch = {
-    result: string
     id: number
     ok: true
+    solution: string
     type: ":return"
   }
 
@@ -256,8 +256,8 @@ export namespace FinalReply {
         id: number
         ok: true
         metadata: Array<MessageMetadata>
-        typeOf: string
         type: ":return"
+        typeOf: string
       }
     | { err: string; id: number; ok: false; type: ":return" }
 

--- a/test/client/client.test.ts
+++ b/test/client/client.test.ts
@@ -106,7 +106,8 @@ describe("Running the client commands", () => {
 
   it("returns the expected result for :version", async () => {
     const actual = await ic.version()
-    assert.deepEqual(actual, expected.version)
+    // We don’t want to tie the test to an actual version.
+    assert.isTrue(actual.ok)
   })
 
   it("returns the expected result for :who-calls", async () => {

--- a/test/client/client.test.ts
+++ b/test/client/client.test.ts
@@ -40,8 +40,7 @@ describe("Running the client commands", () => {
   it("returns the expected result for :browse-namespace.", async () => {
     const actual = await ic.browseNamespace("Language.Reflection")
     // The metadata for an actual namespace is too long to read if the test fails.
-    if ("ok" in actual)
-      actual.ok.declarations = actual.ok.declarations.slice(0, 1)
+    if (actual.ok) actual.declarations = actual.declarations.slice(0, 1)
     assert.deepEqual(actual, expected.browseNamespace)
   })
 

--- a/test/client/expected.ts
+++ b/test/client/expected.ts
@@ -1,335 +1,334 @@
 import { FinalReply } from "../../src/reply"
 
 export const loadFile: FinalReply.LoadFile = {
-  ok: null,
   id: 1,
+  ok: true,
   type: ":return",
 }
 
 export const addClause: FinalReply.AddClause = {
-  ok: "f cat = ?f_rhs",
   id: 2,
+  initialClause: "f cat = ?f_rhs",
+  ok: true,
   type: ":return",
 }
 
 export const addMissing: FinalReply.AddMissing = {
-  ok: "getName Sherlock = ?getName_rhs_1",
   id: 3,
+  missingClauses: "getName Sherlock = ?getName_rhs_1",
+  ok: true,
   type: ":return",
 }
 
 export const apropos: FinalReply.Apropos = {
-  ok: {
-    docs:
-      "\nPrelude.Bits.b8ToBinString : Bits8 -> String\nEncode Bits8 as an 8-character binary string.\n",
-    metadata: [
-      {
-        length: 26,
-        metadata: {
-          decor: ":function",
-          docOverview: "Encode Bits8 as an 8-character binary string.",
-          implicit: ":False",
-          key:
-            "AQAAAAAAAAAADWI4VG9CaW5TdHJpbmcAAAAAAAAAAgAAAAAAAAAEQml0cwAAAAAAAAAHUHJlbHVkZQ==",
-          name: "Prelude.Bits.b8ToBinString",
-          namespace: "Prelude.Bits",
-          type: "Bits8 -> String",
-        },
-        start: 1,
+  docs:
+    "\nPrelude.Bits.b8ToBinString : Bits8 -> String\nEncode Bits8 as an 8-character binary string.\n",
+  metadata: [
+    {
+      length: 26,
+      metadata: {
+        decor: ":function",
+        docOverview: "Encode Bits8 as an 8-character binary string.",
+        implicit: ":False",
+        key:
+          "AQAAAAAAAAAADWI4VG9CaW5TdHJpbmcAAAAAAAAAAgAAAAAAAAAEQml0cwAAAAAAAAAHUHJlbHVkZQ==",
+        name: "Prelude.Bits.b8ToBinString",
+        namespace: "Prelude.Bits",
+        type: "Bits8 -> String",
       },
-      {
-        length: 5,
-        metadata: {
-          decor: ":type",
-          docOverview: "Eight bits (unsigned)",
-          name: "Bits8",
-          type: "Type",
-        },
-        start: 30,
+      start: 1,
+    },
+    {
+      length: 5,
+      metadata: {
+        decor: ":type",
+        docOverview: "Eight bits (unsigned)",
+        name: "Bits8",
+        type: "Type",
       },
-      {
-        length: 6,
-        metadata: {
-          decor: ":type",
-          docOverview: "Strings in some unspecified encoding",
-          name: "String",
-          type: "Type",
-        },
-        start: 39,
+      start: 30,
+    },
+    {
+      length: 6,
+      metadata: {
+        decor: ":type",
+        docOverview: "Strings in some unspecified encoding",
+        name: "String",
+        type: "Type",
       },
-    ],
-  },
+      start: 39,
+    },
+  ],
   id: 4,
+  ok: true,
   type: ":return",
 }
 
 // Abbreviated, only includes the first declaration.
 export const browseNamespace: FinalReply.BrowseNamespace = {
-  ok: {
-    subModules: [
-      "Language.Reflection.Errors",
-      "Language.Reflection.Elab",
-      "Language.Reflection.Elab.Tactics",
-      "Language.Reflection.Elab.ConstructorDefn",
-      "Language.Reflection.Elab.TyDecl",
-      "Language.Reflection.Elab.FunDefn",
-      "Language.Reflection.Elab.DataDefn",
-      "Language.Reflection.Elab.Datatype",
-      "Language.Reflection.SourceLocation",
-      "Language.Reflection.Elab.FunArg",
-    ],
-    declarations: [
-      {
-        name: "ATDouble : ArithTy",
-        metadata: [
-          {
-            start: 0,
-            length: 8,
-            metadata: {
-              name: "Language.Reflection.ATDouble",
-              implicit: ":False",
-              key:
-                "AQAAAAAAAAAACEFURG91YmxlAAAAAAAAAAIAAAAAAAAAClJlZmxlY3Rpb24AAAAAAAAACExhbmd1YWdl",
-              decor: ":data",
-              docOverview: "",
-              type: "ArithTy",
-              namespace: "Language.Reflection",
-            },
+  subModules: [
+    "Language.Reflection.Errors",
+    "Language.Reflection.Elab",
+    "Language.Reflection.Elab.Tactics",
+    "Language.Reflection.Elab.ConstructorDefn",
+    "Language.Reflection.Elab.TyDecl",
+    "Language.Reflection.Elab.FunDefn",
+    "Language.Reflection.Elab.DataDefn",
+    "Language.Reflection.Elab.Datatype",
+    "Language.Reflection.SourceLocation",
+    "Language.Reflection.Elab.FunArg",
+  ],
+  declarations: [
+    {
+      name: "ATDouble : ArithTy",
+      metadata: [
+        {
+          start: 0,
+          length: 8,
+          metadata: {
+            name: "Language.Reflection.ATDouble",
+            implicit: ":False",
+            key:
+              "AQAAAAAAAAAACEFURG91YmxlAAAAAAAAAAIAAAAAAAAAClJlZmxlY3Rpb24AAAAAAAAACExhbmd1YWdl",
+            decor: ":data",
+            docOverview: "",
+            type: "ArithTy",
+            namespace: "Language.Reflection",
           },
-          {
-            start: 11,
-            length: 7,
-            metadata: {
-              name: "Language.Reflection.ArithTy",
-              implicit: ":False",
-              key:
-                "AQAAAAAAAAAAB0FyaXRoVHkAAAAAAAAAAgAAAAAAAAAKUmVmbGVjdGlvbgAAAAAAAAAITGFuZ3VhZ2U=",
-              decor: ":type",
-              docOverview: "",
-              type: "Type",
-              namespace: "Language.Reflection",
-              ttTerm:
-                "AAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAHQXJpdGhUeQAAAAAAAAACAAAAAAAAAApSZWZsZWN0aW9uAAAAAAAAAAhMYW5ndWFnZQ==",
-            },
+        },
+        {
+          start: 11,
+          length: 7,
+          metadata: {
+            name: "Language.Reflection.ArithTy",
+            implicit: ":False",
+            key:
+              "AQAAAAAAAAAAB0FyaXRoVHkAAAAAAAAAAgAAAAAAAAAKUmVmbGVjdGlvbgAAAAAAAAAITGFuZ3VhZ2U=",
+            decor: ":type",
+            docOverview: "",
+            type: "Type",
+            namespace: "Language.Reflection",
+            ttTerm:
+              "AAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAHQXJpdGhUeQAAAAAAAAACAAAAAAAAAApSZWZsZWN0aW9uAAAAAAAAAAhMYW5ndWFnZQ==",
           },
-        ],
-      },
-    ],
-  },
+        },
+      ],
+    },
+  ],
   id: 5,
+  ok: true,
   type: ":return",
 }
 
 export const callsWho: FinalReply.CallsWho = {
-  ok: {
-    caller: {
-      name: "Example.plusTwo",
+  caller: {
+    name: "Example.plusTwo",
+    metadata: [
+      {
+        start: 0,
+        length: 15,
+        metadata: {
+          name: "Example.plusTwo",
+          implicit: ":False",
+          key: "AQAAAAAAAAAAB3BsdXNUd28AAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
+          decor: ":function",
+          docOverview: "",
+          type: "Nat -> Nat",
+          namespace: "Example",
+        },
+      },
+    ],
+  },
+  references: [
+    {
+      name: "Prelude.Nat.Nat",
       metadata: [
         {
           start: 0,
           length: 15,
           metadata: {
-            name: "Example.plusTwo",
+            name: "Prelude.Nat.Nat",
             implicit: ":False",
-            key: "AQAAAAAAAAAAB3BsdXNUd28AAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
-            decor: ":function",
-            docOverview: "",
-            type: "Nat -> Nat",
-            namespace: "Example",
+            key:
+              "AQAAAAAAAAAAA05hdAAAAAAAAAACAAAAAAAAAANOYXQAAAAAAAAAB1ByZWx1ZGU=",
+            decor: ":type",
+            docOverview:
+              "Natural numbers: unbounded, unsigned integers\nwhich can be pattern matched.",
+            type: "Type",
+            namespace: "Prelude.Nat",
           },
         },
       ],
     },
-    references: [
-      {
-        name: "Prelude.Nat.Nat",
-        metadata: [
-          {
-            start: 0,
-            length: 15,
-            metadata: {
-              name: "Prelude.Nat.Nat",
-              implicit: ":False",
-              key:
-                "AQAAAAAAAAAAA05hdAAAAAAAAAACAAAAAAAAAANOYXQAAAAAAAAAB1ByZWx1ZGU=",
-              decor: ":type",
-              docOverview:
-                "Natural numbers: unbounded, unsigned integers\nwhich can be pattern matched.",
-              type: "Type",
-              namespace: "Prelude.Nat",
-            },
+    {
+      name: "Prelude.Nat.plus",
+      metadata: [
+        {
+          start: 0,
+          length: 16,
+          metadata: {
+            name: "Prelude.Nat.plus",
+            implicit: ":False",
+            key:
+              "AQAAAAAAAAAABHBsdXMAAAAAAAAAAgAAAAAAAAADTmF0AAAAAAAAAAdQcmVsdWRl",
+            decor: ":function",
+            docOverview: "Add two natural numbers.",
+            type: "Nat -> Nat -> Nat",
+            namespace: "Prelude.Nat",
           },
-        ],
-      },
-      {
-        name: "Prelude.Nat.plus",
-        metadata: [
-          {
-            start: 0,
-            length: 16,
-            metadata: {
-              name: "Prelude.Nat.plus",
-              implicit: ":False",
-              key:
-                "AQAAAAAAAAAABHBsdXMAAAAAAAAAAgAAAAAAAAADTmF0AAAAAAAAAAdQcmVsdWRl",
-              decor: ":function",
-              docOverview: "Add two natural numbers.",
-              type: "Nat -> Nat -> Nat",
-              namespace: "Prelude.Nat",
-            },
+        },
+      ],
+    },
+    {
+      name: "Prelude.Interfaces.fromInteger",
+      metadata: [
+        {
+          start: 0,
+          length: 30,
+          metadata: {
+            name: "Prelude.Interfaces.fromInteger",
+            implicit: ":False",
+            key:
+              "AQAAAAAAAAAAC2Zyb21JbnRlZ2VyAAAAAAAAAAIAAAAAAAAACkludGVyZmFjZXMAAAAAAAAAB1ByZWx1ZGU=",
+            decor: ":function",
+            docOverview: "Conversion from Integer.",
+            type: "Num ty => Integer -> ty",
+            namespace: "Prelude.Interfaces",
           },
-        ],
-      },
-      {
-        name: "Prelude.Interfaces.fromInteger",
-        metadata: [
-          {
-            start: 0,
-            length: 30,
-            metadata: {
-              name: "Prelude.Interfaces.fromInteger",
-              implicit: ":False",
-              key:
-                "AQAAAAAAAAAAC2Zyb21JbnRlZ2VyAAAAAAAAAAIAAAAAAAAACkludGVyZmFjZXMAAAAAAAAAB1ByZWx1ZGU=",
-              decor: ":function",
-              docOverview: "Conversion from Integer.",
-              type: "Num ty => Integer -> ty",
-              namespace: "Prelude.Interfaces",
-            },
+        },
+      ],
+    },
+    {
+      name: "Prelude.Nat.Nat implementation of Prelude.Interfaces.Num",
+      metadata: [
+        {
+          start: 0,
+          length: 56,
+          metadata: {
+            name: "Prelude.Nat.Nat implementation of Prelude.Interfaces.Num",
+            implicit: ":False",
+            key:
+              "AQMCAQAAAAAAAAAAA051bQAAAAAAAAACAAAAAAAAAApJbnRlcmZhY2VzAAAAAAAAAAdQcmVsdWRlAAAAAAAAAAEAAAAAAAAAA05hdAAAAAAAAAACAAAAAAAAAANOYXQAAAAAAAAAB1ByZWx1ZGU=",
+            decor: ":function",
+            docOverview: "",
+            type: "Num Nat",
+            namespace: "Prelude.Nat",
           },
-        ],
-      },
-      {
-        name: "Prelude.Nat.Nat implementation of Prelude.Interfaces.Num",
-        metadata: [
-          {
-            start: 0,
-            length: 56,
-            metadata: {
-              name: "Prelude.Nat.Nat implementation of Prelude.Interfaces.Num",
-              implicit: ":False",
-              key:
-                "AQMCAQAAAAAAAAAAA051bQAAAAAAAAACAAAAAAAAAApJbnRlcmZhY2VzAAAAAAAAAAdQcmVsdWRlAAAAAAAAAAEAAAAAAAAAA05hdAAAAAAAAAACAAAAAAAAAANOYXQAAAAAAAAAB1ByZWx1ZGU=",
-              decor: ":function",
-              docOverview: "",
-              type: "Num Nat",
-              namespace: "Prelude.Nat",
-            },
-          },
-        ],
-      },
-    ],
-  },
+        },
+      ],
+    },
+  ],
   id: 6,
+  ok: true,
   type: ":return",
 }
 
 export const caseSplit: FinalReply.CaseSplit = {
-  ok: "plusTwo Z = plus 2 n\nplusTwo (S k) = plus 2 n\n",
+  caseClause: "plusTwo Z = plus 2 n\nplusTwo (S k) = plus 2 n\n",
   id: 7,
+  ok: true,
   type: ":return",
 }
 
 export const docsFor: FinalReply.DocsFor = {
-  ok: {
-    docs:
-      "Prelude.Bits.b8ToBinString : Bits8 -> String\n    Encode Bits8 as an 8-character binary string.\n    \n    The function is: Total & public export",
-    metadata: [
-      {
-        start: 0,
-        length: 26,
-        metadata: {
-          name: "Prelude.Bits.b8ToBinString",
-          implicit: ":False",
-          key:
-            "AQAAAAAAAAAADWI4VG9CaW5TdHJpbmcAAAAAAAAAAgAAAAAAAAAEQml0cwAAAAAAAAAHUHJlbHVkZQ==",
-          decor: ":function",
-          docOverview: "Encode Bits8 as an 8-character binary string.",
-          type: "Bits8 -> String",
-          namespace: "Prelude.Bits",
-        },
+  docs:
+    "Prelude.Bits.b8ToBinString : Bits8 -> String\n    Encode Bits8 as an 8-character binary string.\n    \n    The function is: Total & public export",
+  metadata: [
+    {
+      start: 0,
+      length: 26,
+      metadata: {
+        name: "Prelude.Bits.b8ToBinString",
+        implicit: ":False",
+        key:
+          "AQAAAAAAAAAADWI4VG9CaW5TdHJpbmcAAAAAAAAAAgAAAAAAAAAEQml0cwAAAAAAAAAHUHJlbHVkZQ==",
+        decor: ":function",
+        docOverview: "Encode Bits8 as an 8-character binary string.",
+        type: "Bits8 -> String",
+        namespace: "Prelude.Bits",
       },
-      {
-        start: 29,
-        length: 5,
-        metadata: {
-          decor: ":type",
-          type: "Type",
-          docOverview: "Eight bits (unsigned)",
-          name: "Bits8",
-        },
+    },
+    {
+      start: 29,
+      length: 5,
+      metadata: {
+        decor: ":type",
+        type: "Type",
+        docOverview: "Eight bits (unsigned)",
+        name: "Bits8",
       },
-      {
-        start: 38,
-        length: 6,
-        metadata: {
-          decor: ":type",
-          type: "Type",
-          docOverview: "Strings in some unspecified encoding",
-          name: "String",
-        },
+    },
+    {
+      start: 38,
+      length: 6,
+      metadata: {
+        decor: ":type",
+        type: "Type",
+        docOverview: "Strings in some unspecified encoding",
+        name: "String",
       },
-    ],
-  },
+    },
+  ],
   id: 8,
+  ok: true,
   type: ":return",
 }
 
 export const interpret: FinalReply.Interpret = {
-  ok: {
-    result: "4 : Integer",
-    metadata: [
-      {
-        length: 1,
-        metadata: {
-          decor: ":data",
-          docOverview: "An arbitrary-precision integer",
-          name: "4",
-          ttTerm: "AAAAAAAAAAAEAQAAAAAE",
-          type: "Integer",
-        },
-        start: 0,
+  result: "4 : Integer",
+  metadata: [
+    {
+      length: 1,
+      metadata: {
+        decor: ":data",
+        docOverview: "An arbitrary-precision integer",
+        name: "4",
+        ttTerm: "AAAAAAAAAAAEAQAAAAAE",
+        type: "Integer",
       },
-      {
-        length: 7,
-        metadata: {
-          decor: ":type",
-          docOverview: "Arbitrary-precision integers",
-          name: "Integer",
-          ttTerm: "AAAAAAAAAAAECg==",
-          type: "Type",
-        },
-        start: 4,
+      start: 0,
+    },
+    {
+      length: 7,
+      metadata: {
+        decor: ":type",
+        docOverview: "Arbitrary-precision integers",
+        name: "Integer",
+        ttTerm: "AAAAAAAAAAAECg==",
+        type: "Type",
       },
-    ],
-  },
+      start: 4,
+    },
+  ],
   id: 9,
+  ok: true,
   type: ":return",
 }
 
 export const makeCase: FinalReply.MakeCase = {
-  ok: "g n b = case _ of\n             case_val => ?g_rhs\n",
+  caseClause: "g n b = case _ of\n             case_val => ?g_rhs\n",
   id: 10,
+  ok: true,
   type: ":return",
 }
 
 export const makeLemma: FinalReply.MakeLemma = {
-  ok: {
-    declaration: "g_rhs : (n : Nat) -> (b : Bool) -> String",
-    metavariable: "g_rhs n b",
-  },
+  declaration: "g_rhs : (n : Nat) -> (b : Bool) -> String",
+  metavariable: "g_rhs n b",
   id: 11,
+  ok: true,
   type: ":return",
 }
 
 export const makeWith: FinalReply.MakeWith = {
-  ok: "g n b with (_)\n  g n b | with_pat = ?g_rhs_rhs\n",
   id: 12,
+  ok: true,
   type: ":return",
+  withClause: "g n b with (_)\n  g n b | with_pat = ?g_rhs_rhs\n",
 }
 
 export const metavariables: FinalReply.Metavariables = {
-  ok: [
+  metavariables: [
     {
       metavariable: {
         metadata: [
@@ -368,7 +367,7 @@ export const metavariables: FinalReply.Metavariables = {
         name: "Example.f",
         type: "Cat -> String",
       },
-      scope: [],
+      premises: [],
     },
     {
       metavariable: {
@@ -388,7 +387,7 @@ export const metavariables: FinalReply.Metavariables = {
         name: "Example.g_rhs",
         type: "String",
       },
-      scope: [
+      premises: [
         {
           metadata: [
             {
@@ -460,131 +459,131 @@ export const metavariables: FinalReply.Metavariables = {
         name: "Example.n_rhs",
         type: "Nat",
       },
-      scope: [],
+      premises: [],
     },
   ],
   id: 13,
+  ok: true,
   type: ":return",
 }
 
 export const printDefinition: FinalReply.PrintDefinition = {
-  ok: {
-    definition: "data Bool : Type where\n  False : Bool\n  True : Bool",
-    metadata: [
-      {
-        length: 4,
-        metadata: {
-          decor: ":keyword",
-        },
-        start: 0,
+  definition: "data Bool : Type where\n  False : Bool\n  True : Bool",
+  metadata: [
+    {
+      length: 4,
+      metadata: {
+        decor: ":keyword",
       },
-      {
-        length: 4,
-        metadata: {
-          decor: ":type",
-          docOverview: "Boolean Data Type",
-          implicit: ":False",
-          key:
-            "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
-          name: "Prelude.Bool.Bool",
-          namespace: "Prelude.Bool",
-          type: "Type",
-        },
-        start: 5,
+      start: 0,
+    },
+    {
+      length: 4,
+      metadata: {
+        decor: ":type",
+        docOverview: "Boolean Data Type",
+        implicit: ":False",
+        key:
+          "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
+        name: "Prelude.Bool.Bool",
+        namespace: "Prelude.Bool",
+        type: "Type",
       },
-      {
-        length: 4,
-        metadata: {
-          decor: ":type",
-          docOverview: "The type of types",
-          name: "Type",
-          ttTerm:
-            "AAAAAAAAAAAHAAAAAAAAAAASLi9QcmVsdWRlL0Jvb2wuaWRyAAAAAAAAABQ=",
-          type: "Type",
-        },
-        start: 12,
+      start: 5,
+    },
+    {
+      length: 4,
+      metadata: {
+        decor: ":type",
+        docOverview: "The type of types",
+        name: "Type",
+        ttTerm: "AAAAAAAAAAAHAAAAAAAAAAASLi9QcmVsdWRlL0Jvb2wuaWRyAAAAAAAAABQ=",
+        type: "Type",
       },
-      {
-        length: 5,
-        metadata: {
-          decor: ":keyword",
-        },
-        start: 17,
+      start: 12,
+    },
+    {
+      length: 5,
+      metadata: {
+        decor: ":keyword",
       },
-      {
-        length: 5,
-        metadata: {
-          decor: ":data",
-          docOverview: "",
-          implicit: ":False",
-          key:
-            "AQAAAAAAAAAABUZhbHNlAAAAAAAAAAIAAAAAAAAABEJvb2wAAAAAAAAAB1ByZWx1ZGU=",
-          name: "Prelude.Bool.False",
-          namespace: "Prelude.Bool",
-          type: "Bool",
-        },
-        start: 25,
+      start: 17,
+    },
+    {
+      length: 5,
+      metadata: {
+        decor: ":data",
+        docOverview: "",
+        implicit: ":False",
+        key:
+          "AQAAAAAAAAAABUZhbHNlAAAAAAAAAAIAAAAAAAAABEJvb2wAAAAAAAAAB1ByZWx1ZGU=",
+        name: "Prelude.Bool.False",
+        namespace: "Prelude.Bool",
+        type: "Bool",
       },
-      {
-        length: 4,
-        metadata: {
-          decor: ":type",
-          docOverview: "Boolean Data Type",
-          implicit: ":False",
-          key:
-            "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
-          name: "Prelude.Bool.Bool",
-          namespace: "Prelude.Bool",
-          ttTerm:
-            "AAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAEQm9vbAAAAAAAAAACAAAAAAAAAARCb29sAAAAAAAAAAdQcmVsdWRl",
-          type: "Type",
-        },
-        start: 33,
+      start: 25,
+    },
+    {
+      length: 4,
+      metadata: {
+        decor: ":type",
+        docOverview: "Boolean Data Type",
+        implicit: ":False",
+        key:
+          "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
+        name: "Prelude.Bool.Bool",
+        namespace: "Prelude.Bool",
+        ttTerm:
+          "AAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAEQm9vbAAAAAAAAAACAAAAAAAAAARCb29sAAAAAAAAAAdQcmVsdWRl",
+        type: "Type",
       },
-      {
-        length: 4,
-        metadata: {
-          decor: ":data",
-          docOverview: "",
-          implicit: ":False",
-          key:
-            "AQAAAAAAAAAABFRydWUAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
-          name: "Prelude.Bool.True",
-          namespace: "Prelude.Bool",
-          type: "Bool",
-        },
-        start: 40,
+      start: 33,
+    },
+    {
+      length: 4,
+      metadata: {
+        decor: ":data",
+        docOverview: "",
+        implicit: ":False",
+        key:
+          "AQAAAAAAAAAABFRydWUAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
+        name: "Prelude.Bool.True",
+        namespace: "Prelude.Bool",
+        type: "Bool",
       },
-      {
-        length: 4,
-        metadata: {
-          decor: ":type",
-          docOverview: "Boolean Data Type",
-          implicit: ":False",
-          key:
-            "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
-          name: "Prelude.Bool.Bool",
-          namespace: "Prelude.Bool",
-          ttTerm:
-            "AAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAEQm9vbAAAAAAAAAACAAAAAAAAAARCb29sAAAAAAAAAAdQcmVsdWRl",
-          type: "Type",
-        },
-        start: 47,
+      start: 40,
+    },
+    {
+      length: 4,
+      metadata: {
+        decor: ":type",
+        docOverview: "Boolean Data Type",
+        implicit: ":False",
+        key:
+          "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
+        name: "Prelude.Bool.Bool",
+        namespace: "Prelude.Bool",
+        ttTerm:
+          "AAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAEQm9vbAAAAAAAAAACAAAAAAAAAARCb29sAAAAAAAAAAdQcmVsdWRl",
+        type: "Type",
       },
-    ],
-  },
+      start: 47,
+    },
+  ],
   id: 14,
+  ok: true,
   type: ":return",
 }
 
 export const proofSearch: FinalReply.ProofSearch = {
-  ok: "0",
   id: 15,
+  ok: true,
+  solution: "0",
   type: ":return",
 }
 
 export const replCompletions: FinalReply.ReplCompletions = {
-  ok: [
+  completions: [
     "getArgs",
     "getChar",
     "getEnv",
@@ -603,15 +602,59 @@ export const replCompletions: FinalReply.ReplCompletions = {
     "getWitness",
   ],
   id: 16,
+  ok: true,
   type: ":return",
 }
 
 export const typeOf: FinalReply.TypeOf = {
-  ok: {
-    type: "Cat : Type",
+  typeOf: "Cat : Type",
+  metadata: [
+    {
+      length: 3,
+      metadata: {
+        decor: ":type",
+        docOverview: "",
+        implicit: ":False",
+        key: "AQAAAAAAAAAAA0NhdAAAAAAAAAABAAAAAAAAAAdFeGFtcGxl",
+        name: "Example.Cat",
+        namespace: "Example",
+        type: "Type",
+      },
+      start: 0,
+    },
+    {
+      length: 4,
+      metadata: {
+        decor: ":type",
+        docOverview: "The type of types",
+        name: "Type",
+        ttTerm:
+          "AAAAAAAAAAAHAAAAAAAAAAAbLi8uL3Rlc3QvcmVzb3VyY2VzL3Rlc3QuaWRyAAAAAAAAABQ=",
+        type: "Type",
+      },
+      start: 6,
+    },
+  ],
+  id: 17,
+  ok: true,
+  type: ":return",
+}
+
+export const version: FinalReply.Version = {
+  major: 1,
+  minor: 3,
+  patch: 2,
+  tags: [],
+  id: 18,
+  ok: true,
+  type: ":return",
+}
+
+export const whoCalls: FinalReply.WhoCalls = {
+  callee: {
     metadata: [
       {
-        length: 3,
+        length: 11,
         metadata: {
           decor: ":type",
           docOverview: "",
@@ -623,143 +666,102 @@ export const typeOf: FinalReply.TypeOf = {
         },
         start: 0,
       },
-      {
-        length: 4,
-        metadata: {
-          decor: ":type",
-          docOverview: "The type of types",
-          name: "Type",
-          ttTerm:
-            "AAAAAAAAAAAHAAAAAAAAAAAbLi8uL3Rlc3QvcmVzb3VyY2VzL3Rlc3QuaWRyAAAAAAAAABQ=",
-          type: "Type",
-        },
-        start: 6,
-      },
     ],
+    name: "Example.Cat",
   },
-  id: 17,
-  type: ":return",
-}
-
-export const version: FinalReply.Version = {
-  ok: { major: 1, minor: 3, patch: 2, tags: [] },
-  id: 18,
-  type: ":return",
-}
-
-export const whoCalls: FinalReply.WhoCalls = {
-  ok: {
-    callee: {
+  references: [
+    {
       metadata: [
         {
           length: 11,
           metadata: {
-            decor: ":type",
+            decor: ":data",
             docOverview: "",
             implicit: ":False",
-            key: "AQAAAAAAAAAAA0NhdAAAAAAAAAABAAAAAAAAAAdFeGFtcGxl",
-            name: "Example.Cat",
+            key: "AQAAAAAAAAAAA0NhcwAAAAAAAAABAAAAAAAAAAdFeGFtcGxl",
+            name: "Example.Cas",
             namespace: "Example",
-            type: "Type",
+            type: "Cat",
           },
           start: 0,
         },
       ],
-      name: "Example.Cat",
+      name: "Example.Cas",
     },
-    references: [
-      {
-        metadata: [
-          {
-            length: 11,
-            metadata: {
-              decor: ":data",
-              docOverview: "",
-              implicit: ":False",
-              key: "AQAAAAAAAAAAA0NhcwAAAAAAAAABAAAAAAAAAAdFeGFtcGxl",
-              name: "Example.Cas",
-              namespace: "Example",
-              type: "Cat",
-            },
-            start: 0,
+    {
+      metadata: [
+        {
+          length: 12,
+          metadata: {
+            decor: ":data",
+            docOverview: "",
+            implicit: ":False",
+            key: "AQAAAAAAAAAABEx1bmEAAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
+            name: "Example.Luna",
+            namespace: "Example",
+            type: "Cat",
           },
-        ],
-        name: "Example.Cas",
-      },
-      {
-        metadata: [
-          {
-            length: 12,
-            metadata: {
-              decor: ":data",
-              docOverview: "",
-              implicit: ":False",
-              key: "AQAAAAAAAAAABEx1bmEAAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
-              name: "Example.Luna",
-              namespace: "Example",
-              type: "Cat",
-            },
-            start: 0,
+          start: 0,
+        },
+      ],
+      name: "Example.Luna",
+    },
+    {
+      metadata: [
+        {
+          length: 16,
+          metadata: {
+            decor: ":data",
+            docOverview: "",
+            implicit: ":False",
+            key: "AQAAAAAAAAAACFNoZXJsb2NrAAAAAAAAAAEAAAAAAAAAB0V4YW1wbGU=",
+            name: "Example.Sherlock",
+            namespace: "Example",
+            type: "Cat",
           },
-        ],
-        name: "Example.Luna",
-      },
-      {
-        metadata: [
-          {
-            length: 16,
-            metadata: {
-              decor: ":data",
-              docOverview: "",
-              implicit: ":False",
-              key: "AQAAAAAAAAAACFNoZXJsb2NrAAAAAAAAAAEAAAAAAAAAB0V4YW1wbGU=",
-              name: "Example.Sherlock",
-              namespace: "Example",
-              type: "Cat",
-            },
-            start: 0,
+          start: 0,
+        },
+      ],
+      name: "Example.Sherlock",
+    },
+    {
+      metadata: [
+        {
+          length: 9,
+          metadata: {
+            decor: ":metavar",
+            docOverview: "",
+            implicit: ":False",
+            key: "AQAAAAAAAAAAAWYAAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
+            name: "Example.f",
+            namespace: "Example",
+            type: "Cat -> String",
           },
-        ],
-        name: "Example.Sherlock",
-      },
-      {
-        metadata: [
-          {
-            length: 9,
-            metadata: {
-              decor: ":metavar",
-              docOverview: "",
-              implicit: ":False",
-              key: "AQAAAAAAAAAAAWYAAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
-              name: "Example.f",
-              namespace: "Example",
-              type: "Cat -> String",
-            },
-            start: 0,
+          start: 0,
+        },
+      ],
+      name: "Example.f",
+    },
+    {
+      metadata: [
+        {
+          length: 15,
+          metadata: {
+            decor: ":function",
+            docOverview: "",
+            implicit: ":False",
+            key: "AQAAAAAAAAAAB2dldE5hbWUAAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
+            name: "Example.getName",
+            namespace: "Example",
+            type: "Cat -> String",
           },
-        ],
-        name: "Example.f",
-      },
-      {
-        metadata: [
-          {
-            length: 15,
-            metadata: {
-              decor: ":function",
-              docOverview: "",
-              implicit: ":False",
-              key: "AQAAAAAAAAAAB2dldE5hbWUAAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
-              name: "Example.getName",
-              namespace: "Example",
-              type: "Cat -> String",
-            },
-            start: 0,
-          },
-        ],
-        name: "Example.getName",
-      },
-    ],
-  },
+          start: 0,
+        },
+      ],
+      name: "Example.getName",
+    },
+  ],
   id: 19,
+  ok: true,
   type: ":return",
 }

--- a/test/client/expected.ts
+++ b/test/client/expected.ts
@@ -640,16 +640,6 @@ export const typeOf: FinalReply.TypeOf = {
   type: ":return",
 }
 
-export const version: FinalReply.Version = {
-  major: 1,
-  minor: 3,
-  patch: 2,
-  tags: [],
-  id: 18,
-  ok: true,
-  type: ":return",
-}
-
 export const whoCalls: FinalReply.WhoCalls = {
   callee: {
     metadata: [

--- a/test/parser/add-clause.test.ts
+++ b/test/parser/add-clause.test.ts
@@ -11,8 +11,9 @@ describe("Parsing :add-clause reply", () => {
     const payload: S_Exp.AddClause = [":ok", "f cat = ?f_rhs"]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.AddClause = {
-      ok: "f cat = ?f_rhs",
       id: 2,
+      initialClause: "f cat = ?f_rhs",
+      ok: true,
       type: ":return",
     }
 

--- a/test/parser/add-missing.test.ts
+++ b/test/parser/add-missing.test.ts
@@ -14,8 +14,9 @@ describe("Parsing :add-missing reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.AddMissing = {
-      ok: "getName Sherlock = ?getName_rhs_1",
       id: 2,
+      missingClauses: "getName Sherlock = ?getName_rhs_1",
+      ok: true,
       type: ":return",
     }
 

--- a/test/parser/apropos.test.ts
+++ b/test/parser/apropos.test.ts
@@ -52,47 +52,46 @@ describe("Parsing :apropos reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.Apropos = {
-      ok: {
-        docs:
-          "\nPrelude.Bits.b8ToBinString : Bits8 -> String\nEncode Bits8 as an 8-character binary string.\n",
-        metadata: [
-          {
-            length: 26,
-            metadata: {
-              decor: ":function",
-              docOverview: "Encode Bits8 as an 8-character binary string.",
-              implicit: ":False",
-              key:
-                "AQAAAAAAAAAADWI4VG9CaW5TdHJpbmcAAAAAAAAAAgAAAAAAAAAEQml0cwAAAAAAAAAHUHJlbHVkZQ==",
-              name: "Prelude.Bits.b8ToBinString",
-              namespace: "Prelude.Bits",
-              type: "Bits8 -> String",
-            },
-            start: 1,
+      docs:
+        "\nPrelude.Bits.b8ToBinString : Bits8 -> String\nEncode Bits8 as an 8-character binary string.\n",
+      metadata: [
+        {
+          length: 26,
+          metadata: {
+            decor: ":function",
+            docOverview: "Encode Bits8 as an 8-character binary string.",
+            implicit: ":False",
+            key:
+              "AQAAAAAAAAAADWI4VG9CaW5TdHJpbmcAAAAAAAAAAgAAAAAAAAAEQml0cwAAAAAAAAAHUHJlbHVkZQ==",
+            name: "Prelude.Bits.b8ToBinString",
+            namespace: "Prelude.Bits",
+            type: "Bits8 -> String",
           },
-          {
-            length: 5,
-            metadata: {
-              decor: ":type",
-              docOverview: "Eight bits (unsigned)",
-              name: "Bits8",
-              type: "Type",
-            },
-            start: 30,
+          start: 1,
+        },
+        {
+          length: 5,
+          metadata: {
+            decor: ":type",
+            docOverview: "Eight bits (unsigned)",
+            name: "Bits8",
+            type: "Type",
           },
-          {
-            length: 6,
-            metadata: {
-              decor: ":type",
-              docOverview: "Strings in some unspecified encoding",
-              name: "String",
-              type: "Type",
-            },
-            start: 39,
+          start: 30,
+        },
+        {
+          length: 6,
+          metadata: {
+            decor: ":type",
+            docOverview: "Strings in some unspecified encoding",
+            name: "String",
+            type: "Type",
           },
-        ],
-      },
+          start: 39,
+        },
+      ],
       id: 2,
+      ok: true,
       type: ":return",
     }
 
@@ -111,6 +110,7 @@ describe("Parsing :apropos reply", () => {
     const expected: FinalReply.Apropos = {
       err: "No results found",
       id: 2,
+      ok: false,
       type: ":return",
     }
 

--- a/test/parser/browse-namespace.test.ts
+++ b/test/parser/browse-namespace.test.ts
@@ -78,58 +78,57 @@ describe("Parsing :browse-namespace reply", () => {
 
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.BrowseNamespace = {
-      ok: {
-        subModules: [
-          "Language.Reflection.Errors",
-          "Language.Reflection.Elab",
-          "Language.Reflection.Elab.Tactics",
-          "Language.Reflection.Elab.ConstructorDefn",
-          "Language.Reflection.Elab.TyDecl",
-          "Language.Reflection.Elab.FunDefn",
-          "Language.Reflection.Elab.DataDefn",
-          "Language.Reflection.Elab.Datatype",
-          "Language.Reflection.SourceLocation",
-          "Language.Reflection.Elab.FunArg",
-        ],
-        declarations: [
-          {
-            name: "ATDouble : ArithTy",
-            metadata: [
-              {
-                start: 0,
-                length: 8,
-                metadata: {
-                  name: "Language.Reflection.ATDouble",
-                  implicit: ":False",
-                  key:
-                    "AQAAAAAAAAAACEFURG91YmxlAAAAAAAAAAIAAAAAAAAAClJlZmxlY3Rpb24AAAAAAAAACExhbmd1YWdl",
-                  decor: ":data",
-                  docOverview: "",
-                  type: "ArithTy",
-                  namespace: "Language.Reflection",
-                },
+      subModules: [
+        "Language.Reflection.Errors",
+        "Language.Reflection.Elab",
+        "Language.Reflection.Elab.Tactics",
+        "Language.Reflection.Elab.ConstructorDefn",
+        "Language.Reflection.Elab.TyDecl",
+        "Language.Reflection.Elab.FunDefn",
+        "Language.Reflection.Elab.DataDefn",
+        "Language.Reflection.Elab.Datatype",
+        "Language.Reflection.SourceLocation",
+        "Language.Reflection.Elab.FunArg",
+      ],
+      declarations: [
+        {
+          name: "ATDouble : ArithTy",
+          metadata: [
+            {
+              start: 0,
+              length: 8,
+              metadata: {
+                name: "Language.Reflection.ATDouble",
+                implicit: ":False",
+                key:
+                  "AQAAAAAAAAAACEFURG91YmxlAAAAAAAAAAIAAAAAAAAAClJlZmxlY3Rpb24AAAAAAAAACExhbmd1YWdl",
+                decor: ":data",
+                docOverview: "",
+                type: "ArithTy",
+                namespace: "Language.Reflection",
               },
-              {
-                start: 11,
-                length: 7,
-                metadata: {
-                  name: "Language.Reflection.ArithTy",
-                  implicit: ":False",
-                  key:
-                    "AQAAAAAAAAAAB0FyaXRoVHkAAAAAAAAAAgAAAAAAAAAKUmVmbGVjdGlvbgAAAAAAAAAITGFuZ3VhZ2U=",
-                  decor: ":type",
-                  docOverview: "",
-                  type: "Type",
-                  namespace: "Language.Reflection",
-                  ttTerm:
-                    "AAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAHQXJpdGhUeQAAAAAAAAACAAAAAAAAAApSZWZsZWN0aW9uAAAAAAAAAAhMYW5ndWFnZQ==",
-                },
+            },
+            {
+              start: 11,
+              length: 7,
+              metadata: {
+                name: "Language.Reflection.ArithTy",
+                implicit: ":False",
+                key:
+                  "AQAAAAAAAAAAB0FyaXRoVHkAAAAAAAAAAgAAAAAAAAAKUmVmbGVjdGlvbgAAAAAAAAAITGFuZ3VhZ2U=",
+                decor: ":type",
+                docOverview: "",
+                type: "Type",
+                namespace: "Language.Reflection",
+                ttTerm:
+                  "AAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAHQXJpdGhUeQAAAAAAAAACAAAAAAAAAApSZWZsZWN0aW9uAAAAAAAAAAhMYW5ndWFnZQ==",
               },
-            ],
-          },
-        ],
-      },
+            },
+          ],
+        },
+      ],
       id: 2,
+      ok: true,
       type: ":return",
     }
 
@@ -197,43 +196,42 @@ describe("Parsing :browse-namespace reply", () => {
 
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.BrowseNamespace = {
-      ok: {
-        subModules: [],
-        declarations: [
-          {
-            name: "Bool : Type",
-            metadata: [
-              {
-                length: 4,
-                metadata: {
-                  decor: ":type",
-                  docOverview: "Boolean Data Type",
-                  implicit: ":False",
-                  key:
-                    "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
-                  name: "Prelude.Bool.Bool",
-                  namespace: "Prelude.Bool",
-                  type: "Type",
-                },
-                start: 0,
+      subModules: [],
+      declarations: [
+        {
+          name: "Bool : Type",
+          metadata: [
+            {
+              length: 4,
+              metadata: {
+                decor: ":type",
+                docOverview: "Boolean Data Type",
+                implicit: ":False",
+                key:
+                  "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
+                name: "Prelude.Bool.Bool",
+                namespace: "Prelude.Bool",
+                type: "Type",
               },
-              {
-                length: 4,
-                metadata: {
-                  decor: ":type",
-                  docOverview: "The type of types",
-                  name: "Type",
-                  ttTerm:
-                    "AAAAAAAAAAAHAAAAAAAAAAASLi9QcmVsdWRlL0Jvb2wuaWRyAAAAAAAAABQ=",
-                  type: "Type",
-                },
-                start: 7,
+              start: 0,
+            },
+            {
+              length: 4,
+              metadata: {
+                decor: ":type",
+                docOverview: "The type of types",
+                name: "Type",
+                ttTerm:
+                  "AAAAAAAAAAAHAAAAAAAAAAASLi9QcmVsdWRlL0Jvb2wuaWRyAAAAAAAAABQ=",
+                type: "Type",
               },
-            ],
-          },
-        ],
-      },
+              start: 7,
+            },
+          ],
+        },
+      ],
       id: 2,
+      ok: true,
       type: ":return",
     }
 
@@ -255,6 +253,7 @@ describe("Parsing :browse-namespace reply", () => {
     const expected: FinalReply.BrowseNamespace = {
       err: "Invalid or empty namespace",
       id: 2,
+      ok: false,
       type: ":return",
     }
 

--- a/test/parser/calls-who.test.ts
+++ b/test/parser/calls-who.test.ts
@@ -130,107 +130,106 @@ describe("Parsing :calls-who reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.CallsWho = {
-      ok: {
-        caller: {
-          name: "Example.plusTwo",
+      caller: {
+        name: "Example.plusTwo",
+        metadata: [
+          {
+            start: 0,
+            length: 15,
+            metadata: {
+              name: "Example.plusTwo",
+              implicit: ":False",
+              key: "AQAAAAAAAAAAB3BsdXNUd28AAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
+              decor: ":function",
+              docOverview: "",
+              type: "Nat -> Nat",
+              namespace: "Example",
+            },
+          },
+        ],
+      },
+      references: [
+        {
+          name: "Prelude.Nat.Nat",
           metadata: [
             {
               start: 0,
               length: 15,
               metadata: {
-                name: "Example.plusTwo",
+                name: "Prelude.Nat.Nat",
                 implicit: ":False",
-                key: "AQAAAAAAAAAAB3BsdXNUd28AAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
-                decor: ":function",
-                docOverview: "",
-                type: "Nat -> Nat",
-                namespace: "Example",
+                key:
+                  "AQAAAAAAAAAAA05hdAAAAAAAAAACAAAAAAAAAANOYXQAAAAAAAAAB1ByZWx1ZGU=",
+                decor: ":type",
+                docOverview:
+                  "Natural numbers: unbounded, unsigned integers\nwhich can be pattern matched.",
+                type: "Type",
+                namespace: "Prelude.Nat",
               },
             },
           ],
         },
-        references: [
-          {
-            name: "Prelude.Nat.Nat",
-            metadata: [
-              {
-                start: 0,
-                length: 15,
-                metadata: {
-                  name: "Prelude.Nat.Nat",
-                  implicit: ":False",
-                  key:
-                    "AQAAAAAAAAAAA05hdAAAAAAAAAACAAAAAAAAAANOYXQAAAAAAAAAB1ByZWx1ZGU=",
-                  decor: ":type",
-                  docOverview:
-                    "Natural numbers: unbounded, unsigned integers\nwhich can be pattern matched.",
-                  type: "Type",
-                  namespace: "Prelude.Nat",
-                },
+        {
+          name: "Prelude.Nat.plus",
+          metadata: [
+            {
+              start: 0,
+              length: 16,
+              metadata: {
+                name: "Prelude.Nat.plus",
+                implicit: ":False",
+                key:
+                  "AQAAAAAAAAAABHBsdXMAAAAAAAAAAgAAAAAAAAADTmF0AAAAAAAAAAdQcmVsdWRl",
+                decor: ":function",
+                docOverview: "Add two natural numbers.",
+                type: "Nat -> Nat -> Nat",
+                namespace: "Prelude.Nat",
               },
-            ],
-          },
-          {
-            name: "Prelude.Nat.plus",
-            metadata: [
-              {
-                start: 0,
-                length: 16,
-                metadata: {
-                  name: "Prelude.Nat.plus",
-                  implicit: ":False",
-                  key:
-                    "AQAAAAAAAAAABHBsdXMAAAAAAAAAAgAAAAAAAAADTmF0AAAAAAAAAAdQcmVsdWRl",
-                  decor: ":function",
-                  docOverview: "Add two natural numbers.",
-                  type: "Nat -> Nat -> Nat",
-                  namespace: "Prelude.Nat",
-                },
+            },
+          ],
+        },
+        {
+          name: "Prelude.Interfaces.fromInteger",
+          metadata: [
+            {
+              start: 0,
+              length: 30,
+              metadata: {
+                name: "Prelude.Interfaces.fromInteger",
+                implicit: ":False",
+                key:
+                  "AQAAAAAAAAAAC2Zyb21JbnRlZ2VyAAAAAAAAAAIAAAAAAAAACkludGVyZmFjZXMAAAAAAAAAB1ByZWx1ZGU=",
+                decor: ":function",
+                docOverview: "Conversion from Integer.",
+                type: "Num ty => Integer -> ty",
+                namespace: "Prelude.Interfaces",
               },
-            ],
-          },
-          {
-            name: "Prelude.Interfaces.fromInteger",
-            metadata: [
-              {
-                start: 0,
-                length: 30,
-                metadata: {
-                  name: "Prelude.Interfaces.fromInteger",
-                  implicit: ":False",
-                  key:
-                    "AQAAAAAAAAAAC2Zyb21JbnRlZ2VyAAAAAAAAAAIAAAAAAAAACkludGVyZmFjZXMAAAAAAAAAB1ByZWx1ZGU=",
-                  decor: ":function",
-                  docOverview: "Conversion from Integer.",
-                  type: "Num ty => Integer -> ty",
-                  namespace: "Prelude.Interfaces",
-                },
+            },
+          ],
+        },
+        {
+          name: "Prelude.Nat.Nat implementation of Prelude.Interfaces.Num",
+          metadata: [
+            {
+              start: 0,
+              length: 56,
+              metadata: {
+                name:
+                  "Prelude.Nat.Nat implementation of Prelude.Interfaces.Num",
+                implicit: ":False",
+                key:
+                  "AQMCAQAAAAAAAAAAA051bQAAAAAAAAACAAAAAAAAAApJbnRlcmZhY2VzAAAAAAAAAAdQcmVsdWRlAAAAAAAAAAEAAAAAAAAAA05hdAAAAAAAAAACAAAAAAAAAANOYXQAAAAAAAAAB1ByZWx1ZGU=",
+                decor: ":function",
+                docOverview: "",
+                type: "Num Nat",
+                namespace: "Prelude.Nat",
               },
-            ],
-          },
-          {
-            name: "Prelude.Nat.Nat implementation of Prelude.Interfaces.Num",
-            metadata: [
-              {
-                start: 0,
-                length: 56,
-                metadata: {
-                  name:
-                    "Prelude.Nat.Nat implementation of Prelude.Interfaces.Num",
-                  implicit: ":False",
-                  key:
-                    "AQMCAQAAAAAAAAAAA051bQAAAAAAAAACAAAAAAAAAApJbnRlcmZhY2VzAAAAAAAAAAdQcmVsdWRlAAAAAAAAAAEAAAAAAAAAA05hdAAAAAAAAAACAAAAAAAAAANOYXQAAAAAAAAAB1ByZWx1ZGU=",
-                  decor: ":function",
-                  docOverview: "",
-                  type: "Num Nat",
-                  namespace: "Prelude.Nat",
-                },
-              },
-            ],
-          },
-        ],
-      },
+            },
+          ],
+        },
+      ],
       id: 2,
+      ok: true,
       type: ":return",
     }
 
@@ -247,11 +246,10 @@ describe("Parsing :calls-who reply", () => {
     const payload: S_Exp.CallsWho = [":ok", []]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.CallsWho = {
-      ok: {
-        caller: null,
-        references: [],
-      },
+      caller: null,
+      references: [],
       id: 2,
+      ok: true,
       type: ":return",
     }
 

--- a/test/parser/case-split.test.ts
+++ b/test/parser/case-split.test.ts
@@ -14,8 +14,9 @@ describe("Parsing :case-split reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.CaseSplit = {
-      ok: "plusTwo Z = plus 2 n\nplusTwo (S k) = plus 2 n\n",
+      caseClause: "plusTwo Z = plus 2 n\nplusTwo (S k) = plus 2 n\n",
       id: 2,
+      ok: true,
       type: ":return",
     }
 
@@ -37,6 +38,7 @@ describe("Parsing :case-split reply", () => {
     const expected: FinalReply.CaseSplit = {
       err: `Elaborating {__infer_0} arg {ival_0}: Internal error: "Unelaboratable syntactic form (Example.plusTwo : (n : Nat) ->\nNat)"`,
       id: 2,
+      ok: false,
       type: ":return",
     }
 

--- a/test/parser/docs-for.test.ts
+++ b/test/parser/docs-for.test.ts
@@ -52,47 +52,46 @@ describe("Parsing :case-split reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.DocsFor = {
-      ok: {
-        docs:
-          "Prelude.Bits.b8ToBinString : Bits8 -> String\n    Encode Bits8 as an 8-character binary string.\n    \n    The function is: Total & public export",
-        metadata: [
-          {
-            start: 0,
-            length: 26,
-            metadata: {
-              name: "Prelude.Bits.b8ToBinString",
-              implicit: ":False",
-              key:
-                "AQAAAAAAAAAADWI4VG9CaW5TdHJpbmcAAAAAAAAAAgAAAAAAAAAEQml0cwAAAAAAAAAHUHJlbHVkZQ==",
-              decor: ":function",
-              docOverview: "Encode Bits8 as an 8-character binary string.",
-              type: "Bits8 -> String",
-              namespace: "Prelude.Bits",
-            },
+      docs:
+        "Prelude.Bits.b8ToBinString : Bits8 -> String\n    Encode Bits8 as an 8-character binary string.\n    \n    The function is: Total & public export",
+      metadata: [
+        {
+          start: 0,
+          length: 26,
+          metadata: {
+            name: "Prelude.Bits.b8ToBinString",
+            implicit: ":False",
+            key:
+              "AQAAAAAAAAAADWI4VG9CaW5TdHJpbmcAAAAAAAAAAgAAAAAAAAAEQml0cwAAAAAAAAAHUHJlbHVkZQ==",
+            decor: ":function",
+            docOverview: "Encode Bits8 as an 8-character binary string.",
+            type: "Bits8 -> String",
+            namespace: "Prelude.Bits",
           },
-          {
-            start: 29,
-            length: 5,
-            metadata: {
-              decor: ":type",
-              type: "Type",
-              docOverview: "Eight bits (unsigned)",
-              name: "Bits8",
-            },
+        },
+        {
+          start: 29,
+          length: 5,
+          metadata: {
+            decor: ":type",
+            type: "Type",
+            docOverview: "Eight bits (unsigned)",
+            name: "Bits8",
           },
-          {
-            start: 38,
-            length: 6,
-            metadata: {
-              decor: ":type",
-              type: "Type",
-              docOverview: "Strings in some unspecified encoding",
-              name: "String",
-            },
+        },
+        {
+          start: 38,
+          length: 6,
+          metadata: {
+            decor: ":type",
+            type: "Type",
+            docOverview: "Strings in some unspecified encoding",
+            name: "String",
           },
-        ],
-      },
+        },
+      ],
       id: 2,
+      ok: true,
       type: ":return",
     }
 
@@ -114,6 +113,7 @@ describe("Parsing :case-split reply", () => {
     const expected: FinalReply.DocsFor = {
       err: "No documentation for Blue Notebook #10",
       id: 2,
+      ok: false,
       type: ":return",
     }
 

--- a/test/parser/interpret.test.ts
+++ b/test/parser/interpret.test.ts
@@ -184,34 +184,33 @@ describe("Parsing :interpret reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.Interpret = {
-      ok: {
-        result: "4 : Integer",
-        metadata: [
-          {
-            length: 1,
-            metadata: {
-              decor: ":data",
-              docOverview: "An arbitrary-precision integer",
-              name: "4",
-              ttTerm: "AAAAAAAAAAAEAQAAAAAE",
-              type: "Integer",
-            },
-            start: 0,
+      result: "4 : Integer",
+      metadata: [
+        {
+          length: 1,
+          metadata: {
+            decor: ":data",
+            docOverview: "An arbitrary-precision integer",
+            name: "4",
+            ttTerm: "AAAAAAAAAAAEAQAAAAAE",
+            type: "Integer",
           },
-          {
-            length: 7,
-            metadata: {
-              decor: ":type",
-              docOverview: "Arbitrary-precision integers",
-              name: "Integer",
-              ttTerm: "AAAAAAAAAAAECg==",
-              type: "Type",
-            },
-            start: 4,
+          start: 0,
+        },
+        {
+          length: 7,
+          metadata: {
+            decor: ":type",
+            docOverview: "Arbitrary-precision integers",
+            name: "Integer",
+            ttTerm: "AAAAAAAAAAAECg==",
+            type: "Type",
           },
-        ],
-      },
+          start: 4,
+        },
+      ],
       id: 2,
+      ok: true,
       type: ":return",
     }
 
@@ -258,36 +257,35 @@ describe("Parsing :interpret reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.Interpret = {
-      err: {
-        message:
-          "When checking an application of function Prelude.Interfaces.*:\n        No such variable cas",
-        metadata: [
-          {
-            length: 20,
-            metadata: {
-              decor: ":function",
-              docOverview: "",
-              implicit: ":False",
-              key:
-                "AQAAAAAAAAAAASoAAAAAAAAAAgAAAAAAAAAKSW50ZXJmYWNlcwAAAAAAAAAHUHJlbHVkZQ==",
-              name: "Prelude.Interfaces.*",
-              namespace: "Prelude.Interfaces",
-              type: "Num ty => ty -> ty -> ty",
-            },
-            start: 41,
+      err:
+        "When checking an application of function Prelude.Interfaces.*:\n        No such variable cas",
+      metadata: [
+        {
+          length: 20,
+          metadata: {
+            decor: ":function",
+            docOverview: "",
+            implicit: ":False",
+            key:
+              "AQAAAAAAAAAAASoAAAAAAAAAAgAAAAAAAAAKSW50ZXJmYWNlcwAAAAAAAAAHUHJlbHVkZQ==",
+            name: "Prelude.Interfaces.*",
+            namespace: "Prelude.Interfaces",
+            type: "Num ty => ty -> ty -> ty",
           },
-          {
-            length: 3,
-            metadata: {
-              implicit: ":False",
-              key: "AAAAAAAAAAADY2Fz",
-              name: "cas",
-            },
-            start: 88,
+          start: 41,
+        },
+        {
+          length: 3,
+          metadata: {
+            implicit: ":False",
+            key: "AAAAAAAAAAADY2Fz",
+            name: "cas",
           },
-        ],
-      },
+          start: 88,
+        },
+      ],
       id: 2,
+      ok: false,
       type: ":return",
     }
 
@@ -307,11 +305,10 @@ describe("Parsing :interpret reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 3]
     const expected: FinalReply.Interpret = {
-      err: {
-        message: `(input):1:1:\n  |\n1 | -----\n  | ^^^^^\nunexpected "-----"\nexpecting ':', dependent type signature, or end of input\n`,
-        metadata: [],
-      },
+      err: `(input):1:1:\n  |\n1 | -----\n  | ^^^^^\nunexpected "-----"\nexpecting ':', dependent type signature, or end of input\n`,
+      metadata: [],
       id: 3,
+      ok: false,
       type: ":return",
     }
 

--- a/test/parser/load-file.test.ts
+++ b/test/parser/load-file.test.ts
@@ -107,7 +107,7 @@ describe("Parsing :load-file reply", () => {
     const payload: S_Exp.LoadFileOk = [":ok", []]
     const rootExpr: RootExpr = [":return", payload, 1]
     const expected: FinalReply.LoadFile = {
-      ok: null,
+      ok: true,
       id: 1,
       type: ":return",
     }
@@ -246,6 +246,7 @@ describe("Parsing :load-file reply", () => {
     const expected: FinalReply.LoadFile = {
       err: "didn't load ./test/resources/test.idr",
       id: 1,
+      ok: false,
       type: ":return",
     }
 

--- a/test/parser/make-case.test.ts
+++ b/test/parser/make-case.test.ts
@@ -14,8 +14,9 @@ describe("Parsing :make-case reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.MakeCase = {
-      ok: "g n b = case _ of\n             case_val => ?g_rhs\n",
+      caseClause: "g n b = case _ of\n             case_val => ?g_rhs\n",
       id: 2,
+      ok: true,
       type: ":return",
     }
 
@@ -33,8 +34,9 @@ describe("Parsing :make-case reply", () => {
     const payload: S_Exp.MakeCase = [":ok", "\n"]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.MakeCase = {
-      ok: "\n",
+      caseClause: "\n",
       id: 2,
+      ok: true,
       type: ":return",
     }
 

--- a/test/parser/make-lemma.test.ts
+++ b/test/parser/make-lemma.test.ts
@@ -18,11 +18,10 @@ describe("Parsing :make-lemma reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.MakeLemma = {
-      ok: {
-        declaration: "g_rhs : (n : Nat) -> (b : Bool) -> String",
-        metavariable: "g_rhs n b",
-      },
+      declaration: "g_rhs : (n : Nat) -> (b : Bool) -> String",
       id: 2,
+      metavariable: "g_rhs n b",
+      ok: true,
       type: ":return",
     }
 
@@ -41,6 +40,7 @@ describe("Parsing :make-lemma reply", () => {
     const expected: FinalReply.MakeLemma = {
       err: "NoSuchVariable nix",
       id: 2,
+      ok: false,
       type: ":return",
     }
 

--- a/test/parser/make-with.test.ts
+++ b/test/parser/make-with.test.ts
@@ -14,9 +14,10 @@ describe("Parsing :make-with reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.MakeWith = {
-      ok: "g n b with (_)\n  g n b | with_pat = ?g_rhs_rhs\n",
       id: 2,
+      ok: true,
       type: ":return",
+      withClause: "g n b with (_)\n  g n b | with_pat = ?g_rhs_rhs\n",
     }
 
     const tokens = lex(sexp)

--- a/test/parser/metavariables.test.ts
+++ b/test/parser/metavariables.test.ts
@@ -149,7 +149,7 @@ describe("Parsing :metavariables reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.Metavariables = {
-      ok: [
+      metavariables: [
         {
           metavariable: {
             metadata: [
@@ -188,7 +188,7 @@ describe("Parsing :metavariables reply", () => {
             name: "Example.f",
             type: "Cat -> String",
           },
-          scope: [],
+          premises: [],
         },
         {
           metavariable: {
@@ -208,7 +208,7 @@ describe("Parsing :metavariables reply", () => {
             name: "Example.g_rhs",
             type: "String",
           },
-          scope: [
+          premises: [
             {
               metadata: [
                 {
@@ -258,6 +258,7 @@ describe("Parsing :metavariables reply", () => {
         },
       ],
       id: 2,
+      ok: true,
       type: ":return",
     }
 

--- a/test/parser/print-definition.test.ts
+++ b/test/parser/print-definition.test.ts
@@ -138,112 +138,111 @@ describe("Parsing :print-definition reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.PrintDefinition = {
-      ok: {
-        definition: "data Bool : Type where\n  False : Bool\n  True : Bool",
-        metadata: [
-          {
-            length: 4,
-            metadata: {
-              decor: ":keyword",
-            },
-            start: 0,
+      definition: "data Bool : Type where\n  False : Bool\n  True : Bool",
+      metadata: [
+        {
+          length: 4,
+          metadata: {
+            decor: ":keyword",
           },
-          {
-            length: 4,
-            metadata: {
-              decor: ":type",
-              docOverview: "Boolean Data Type",
-              implicit: ":False",
-              key:
-                "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
-              name: "Prelude.Bool.Bool",
-              namespace: "Prelude.Bool",
-              type: "Type",
-            },
-            start: 5,
+          start: 0,
+        },
+        {
+          length: 4,
+          metadata: {
+            decor: ":type",
+            docOverview: "Boolean Data Type",
+            implicit: ":False",
+            key:
+              "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
+            name: "Prelude.Bool.Bool",
+            namespace: "Prelude.Bool",
+            type: "Type",
           },
-          {
-            length: 4,
-            metadata: {
-              decor: ":type",
-              docOverview: "The type of types",
-              name: "Type",
-              ttTerm:
-                "AAAAAAAAAAAHAAAAAAAAAAASLi9QcmVsdWRlL0Jvb2wuaWRyAAAAAAAAABQ=",
-              type: "Type",
-            },
-            start: 12,
+          start: 5,
+        },
+        {
+          length: 4,
+          metadata: {
+            decor: ":type",
+            docOverview: "The type of types",
+            name: "Type",
+            ttTerm:
+              "AAAAAAAAAAAHAAAAAAAAAAASLi9QcmVsdWRlL0Jvb2wuaWRyAAAAAAAAABQ=",
+            type: "Type",
           },
-          {
-            length: 5,
-            metadata: {
-              decor: ":keyword",
-            },
-            start: 17,
+          start: 12,
+        },
+        {
+          length: 5,
+          metadata: {
+            decor: ":keyword",
           },
-          {
-            length: 5,
-            metadata: {
-              decor: ":data",
-              docOverview: "",
-              implicit: ":False",
-              key:
-                "AQAAAAAAAAAABUZhbHNlAAAAAAAAAAIAAAAAAAAABEJvb2wAAAAAAAAAB1ByZWx1ZGU=",
-              name: "Prelude.Bool.False",
-              namespace: "Prelude.Bool",
-              type: "Bool",
-            },
-            start: 25,
+          start: 17,
+        },
+        {
+          length: 5,
+          metadata: {
+            decor: ":data",
+            docOverview: "",
+            implicit: ":False",
+            key:
+              "AQAAAAAAAAAABUZhbHNlAAAAAAAAAAIAAAAAAAAABEJvb2wAAAAAAAAAB1ByZWx1ZGU=",
+            name: "Prelude.Bool.False",
+            namespace: "Prelude.Bool",
+            type: "Bool",
           },
-          {
-            length: 4,
-            metadata: {
-              decor: ":type",
-              docOverview: "Boolean Data Type",
-              implicit: ":False",
-              key:
-                "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
-              name: "Prelude.Bool.Bool",
-              namespace: "Prelude.Bool",
-              ttTerm:
-                "AAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAEQm9vbAAAAAAAAAACAAAAAAAAAARCb29sAAAAAAAAAAdQcmVsdWRl",
-              type: "Type",
-            },
-            start: 33,
+          start: 25,
+        },
+        {
+          length: 4,
+          metadata: {
+            decor: ":type",
+            docOverview: "Boolean Data Type",
+            implicit: ":False",
+            key:
+              "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
+            name: "Prelude.Bool.Bool",
+            namespace: "Prelude.Bool",
+            ttTerm:
+              "AAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAEQm9vbAAAAAAAAAACAAAAAAAAAARCb29sAAAAAAAAAAdQcmVsdWRl",
+            type: "Type",
           },
-          {
-            length: 4,
-            metadata: {
-              decor: ":data",
-              docOverview: "",
-              implicit: ":False",
-              key:
-                "AQAAAAAAAAAABFRydWUAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
-              name: "Prelude.Bool.True",
-              namespace: "Prelude.Bool",
-              type: "Bool",
-            },
-            start: 40,
+          start: 33,
+        },
+        {
+          length: 4,
+          metadata: {
+            decor: ":data",
+            docOverview: "",
+            implicit: ":False",
+            key:
+              "AQAAAAAAAAAABFRydWUAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
+            name: "Prelude.Bool.True",
+            namespace: "Prelude.Bool",
+            type: "Bool",
           },
-          {
-            length: 4,
-            metadata: {
-              decor: ":type",
-              docOverview: "Boolean Data Type",
-              implicit: ":False",
-              key:
-                "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
-              name: "Prelude.Bool.Bool",
-              namespace: "Prelude.Bool",
-              ttTerm:
-                "AAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAEQm9vbAAAAAAAAAACAAAAAAAAAARCb29sAAAAAAAAAAdQcmVsdWRl",
-              type: "Type",
-            },
-            start: 47,
+          start: 40,
+        },
+        {
+          length: 4,
+          metadata: {
+            decor: ":type",
+            docOverview: "Boolean Data Type",
+            implicit: ":False",
+            key:
+              "AQAAAAAAAAAABEJvb2wAAAAAAAAAAgAAAAAAAAAEQm9vbAAAAAAAAAAHUHJlbHVkZQ==",
+            name: "Prelude.Bool.Bool",
+            namespace: "Prelude.Bool",
+            ttTerm:
+              "AAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAEQm9vbAAAAAAAAAACAAAAAAAAAARCb29sAAAAAAAAAAdQcmVsdWRl",
+            type: "Type",
           },
-        ],
-      },
+          start: 47,
+        },
+      ],
       id: 2,
+      ok: true,
       type: ":return",
     }
 
@@ -262,6 +261,7 @@ describe("Parsing :print-definition reply", () => {
     const expected: FinalReply.PrintDefinition = {
       err: "Not found",
       id: 2,
+      ok: false,
       type: ":return",
     }
 

--- a/test/parser/proof-search.test.ts
+++ b/test/parser/proof-search.test.ts
@@ -11,8 +11,9 @@ describe("Parsing :proof-search reply", () => {
     const payload: S_Exp.ProofSearch = [":ok", "0"]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.ProofSearch = {
-      ok: "0",
       id: 2,
+      ok: true,
+      solution: "0",
       type: ":return",
     }
 

--- a/test/parser/repl-completions.test.ts
+++ b/test/parser/repl-completions.test.ts
@@ -34,7 +34,7 @@ describe("Parsing :repl-completions reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.ReplCompletions = {
-      ok: [
+      completions: [
         "getArgs",
         "getChar",
         "getEnv",
@@ -53,6 +53,7 @@ describe("Parsing :repl-completions reply", () => {
         "getWitness",
       ],
       id: 2,
+      ok: true,
       type: ":return",
     }
 

--- a/test/parser/type-of.test.ts
+++ b/test/parser/type-of.test.ts
@@ -50,37 +50,36 @@ describe("Parsing :type-of reply", () => {
 
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.TypeOf = {
-      ok: {
-        type: "Cat : Type",
-        metadata: [
-          {
-            length: 3,
-            metadata: {
-              decor: ":type",
-              docOverview: "",
-              implicit: ":False",
-              key: "AQAAAAAAAAAAA0NhdAAAAAAAAAABAAAAAAAAAAdFeGFtcGxl",
-              name: "Example.Cat",
-              namespace: "Example",
-              type: "Type",
-            },
-            start: 0,
+      typeOf: "Cat : Type",
+      metadata: [
+        {
+          length: 3,
+          metadata: {
+            decor: ":type",
+            docOverview: "",
+            implicit: ":False",
+            key: "AQAAAAAAAAAAA0NhdAAAAAAAAAABAAAAAAAAAAdFeGFtcGxl",
+            name: "Example.Cat",
+            namespace: "Example",
+            type: "Type",
           },
-          {
-            length: 4,
-            metadata: {
-              decor: ":type",
-              docOverview: "The type of types",
-              name: "Type",
-              ttTerm:
-                "AAAAAAAAAAAHAAAAAAAAAAAbLi8uL3Rlc3QvcmVzb3VyY2VzL3Rlc3QuaWRyAAAAAAAAABQ=",
-              type: "Type",
-            },
-            start: 6,
+          start: 0,
+        },
+        {
+          length: 4,
+          metadata: {
+            decor: ":type",
+            docOverview: "The type of types",
+            name: "Type",
+            ttTerm:
+              "AAAAAAAAAAAHAAAAAAAAAAAbLi8uL3Rlc3QvcmVzb3VyY2VzL3Rlc3QuaWRyAAAAAAAAABQ=",
+            type: "Type",
           },
-        ],
-      },
+          start: 6,
+        },
+      ],
       id: 2,
+      ok: true,
       type: ":return",
     }
 
@@ -100,6 +99,7 @@ describe("Parsing :type-of reply", () => {
     const expected: FinalReply.TypeOf = {
       err: "No such variable luna",
       id: 2,
+      ok: false,
       type: ":return",
     }
 

--- a/test/parser/version.test.ts
+++ b/test/parser/version.test.ts
@@ -12,8 +12,12 @@ describe("Parsing :version reply", () => {
     const payload: S_Exp.Version = [":ok", [[1, 3, 2], []]]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.Version = {
-      ok: { major: 1, minor: 3, patch: 2, tags: [] },
       id: 2,
+      major: 1,
+      minor: 3,
+      ok: true,
+      patch: 2,
+      tags: [],
       type: ":return",
     }
 
@@ -31,8 +35,12 @@ describe("Parsing :version reply", () => {
     const payload: S_Exp.Version = [":ok", [[1, 3, 2], ["git:PRE"]]]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.Version = {
-      ok: { major: 1, minor: 3, patch: 2, tags: ["git:PRE"] },
       id: 2,
+      major: 1,
+      minor: 3,
+      ok: true,
+      patch: 2,
+      tags: ["git:PRE"],
       type: ":return",
     }
 

--- a/test/parser/who-calls.test.ts
+++ b/test/parser/who-calls.test.ts
@@ -142,121 +142,118 @@ describe("Parsing :who-calls reply", () => {
     ]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.WhoCalls = {
-      ok: {
-        callee: {
+      callee: {
+        metadata: [
+          {
+            length: 11,
+            metadata: {
+              decor: ":type",
+              docOverview: "",
+              implicit: ":False",
+              key: "AQAAAAAAAAAAA0NhdAAAAAAAAAABAAAAAAAAAAdFeGFtcGxl",
+              name: "Example.Cat",
+              namespace: "Example",
+              type: "Type",
+            },
+            start: 0,
+          },
+        ],
+        name: "Example.Cat",
+      },
+      references: [
+        {
           metadata: [
             {
               length: 11,
               metadata: {
-                decor: ":type",
+                decor: ":data",
                 docOverview: "",
                 implicit: ":False",
-                key: "AQAAAAAAAAAAA0NhdAAAAAAAAAABAAAAAAAAAAdFeGFtcGxl",
-                name: "Example.Cat",
+                key: "AQAAAAAAAAAAA0NhcwAAAAAAAAABAAAAAAAAAAdFeGFtcGxl",
+                name: "Example.Cas",
                 namespace: "Example",
-                type: "Type",
+                type: "Cat",
               },
               start: 0,
             },
           ],
-          name: "Example.Cat",
+          name: "Example.Cas",
         },
-        references: [
-          {
-            metadata: [
-              {
-                length: 11,
-                metadata: {
-                  decor: ":data",
-                  docOverview: "",
-                  implicit: ":False",
-                  key: "AQAAAAAAAAAAA0NhcwAAAAAAAAABAAAAAAAAAAdFeGFtcGxl",
-                  name: "Example.Cas",
-                  namespace: "Example",
-                  type: "Cat",
-                },
-                start: 0,
+        {
+          metadata: [
+            {
+              length: 12,
+              metadata: {
+                decor: ":data",
+                docOverview: "",
+                implicit: ":False",
+                key: "AQAAAAAAAAAABEx1bmEAAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
+                name: "Example.Luna",
+                namespace: "Example",
+                type: "Cat",
               },
-            ],
-            name: "Example.Cas",
-          },
-          {
-            metadata: [
-              {
-                length: 12,
-                metadata: {
-                  decor: ":data",
-                  docOverview: "",
-                  implicit: ":False",
-                  key: "AQAAAAAAAAAABEx1bmEAAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
-                  name: "Example.Luna",
-                  namespace: "Example",
-                  type: "Cat",
-                },
-                start: 0,
+              start: 0,
+            },
+          ],
+          name: "Example.Luna",
+        },
+        {
+          metadata: [
+            {
+              length: 16,
+              metadata: {
+                decor: ":data",
+                docOverview: "",
+                implicit: ":False",
+                key: "AQAAAAAAAAAACFNoZXJsb2NrAAAAAAAAAAEAAAAAAAAAB0V4YW1wbGU=",
+                name: "Example.Sherlock",
+                namespace: "Example",
+                type: "Cat",
               },
-            ],
-            name: "Example.Luna",
-          },
-          {
-            metadata: [
-              {
-                length: 16,
-                metadata: {
-                  decor: ":data",
-                  docOverview: "",
-                  implicit: ":False",
-                  key:
-                    "AQAAAAAAAAAACFNoZXJsb2NrAAAAAAAAAAEAAAAAAAAAB0V4YW1wbGU=",
-                  name: "Example.Sherlock",
-                  namespace: "Example",
-                  type: "Cat",
-                },
-                start: 0,
+              start: 0,
+            },
+          ],
+          name: "Example.Sherlock",
+        },
+        {
+          metadata: [
+            {
+              length: 9,
+              metadata: {
+                decor: ":metavar",
+                docOverview: "",
+                implicit: ":False",
+                key: "AQAAAAAAAAAAAWYAAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
+                name: "Example.f",
+                namespace: "Example",
+                type: "Cat -> String",
               },
-            ],
-            name: "Example.Sherlock",
-          },
-          {
-            metadata: [
-              {
-                length: 9,
-                metadata: {
-                  decor: ":metavar",
-                  docOverview: "",
-                  implicit: ":False",
-                  key: "AQAAAAAAAAAAAWYAAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
-                  name: "Example.f",
-                  namespace: "Example",
-                  type: "Cat -> String",
-                },
-                start: 0,
+              start: 0,
+            },
+          ],
+          name: "Example.f",
+        },
+        {
+          metadata: [
+            {
+              length: 15,
+              metadata: {
+                decor: ":function",
+                docOverview: "",
+                implicit: ":False",
+                key: "AQAAAAAAAAAAB2dldE5hbWUAAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
+                name: "Example.getName",
+                namespace: "Example",
+                type: "Cat -> String",
               },
-            ],
-            name: "Example.f",
-          },
-          {
-            metadata: [
-              {
-                length: 15,
-                metadata: {
-                  decor: ":function",
-                  docOverview: "",
-                  implicit: ":False",
-                  key:
-                    "AQAAAAAAAAAAB2dldE5hbWUAAAAAAAAAAQAAAAAAAAAHRXhhbXBsZQ==",
-                  name: "Example.getName",
-                  namespace: "Example",
-                  type: "Cat -> String",
-                },
-                start: 0,
-              },
-            ],
-            name: "Example.getName",
-          },
-        ],
-      },
+              start: 0,
+            },
+          ],
+          name: "Example.getName",
+        },
+      ],
       id: 2,
+      ok: true,
       type: ":return",
     }
     const tokens = lex(sexp)
@@ -271,11 +268,10 @@ describe("Parsing :who-calls reply", () => {
     const payload: S_Exp.WhoCalls = [":ok", []]
     const rootExpr: RootExpr = [":return", payload, 2]
     const expected: FinalReply.WhoCalls = {
-      ok: {
-        callee: null,
-        references: [],
-      },
+      callee: null,
+      references: [],
       id: 2,
+      ok: true,
       type: ":return",
     }
 


### PR DESCRIPTION
Resolves https://github.com/meraymond2/idris-ide-client/issues/5 and https://github.com/meraymond2/idris-ide-client/issues/3. 

Makes `ok` a Boolean in all of the FinalReply types, so that it can more easily be used as a discriminator, which has the nice side effect of making it resemble the fetch api. I've used the opportunity to flatten the reply objects.

I've also extracted all of the unnamed nested objects in those Replies, and exported them. I've added a few other types to the top-level export that I've needed in https://github.com/meraymond2/idris-vscode. 