### PR TITLE
Rm extraneous carriage returns

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -35,7 +35,9 @@ export class IdrisClient {
     this.input = input
     this.output = output
     this.output.on("data", (chunk: Buffer | string) => {
-      this.messageBuffer = this.messageBuffer + chunk.toString("utf8")
+      // On Windows, newlines are \r\n, but the length-header doesn’t take that into account, so they need to be removed.
+      const newChunk = chunk.toString("utf8").replace(/\r\n/g, "\n")
+      this.messageBuffer = this.messageBuffer + newChunk
       this.consumeOutput()
     })
   }


### PR DESCRIPTION
Fixes https://github.com/meraymond2/idris-ide-client/issues/20.

On Windows, newlines in IDE messages are `\r\n`, but the length header assumes single-character newline chars, so the logic to chop up the message buffer into s-exps gets messed up.

I finally got around to setting up an env on my Windows partition, and now the tests are passing. 