### PR TITLE
Version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 ## Unreleased
 ### Added
 ### Changed
+### Fixed
+
+## v0.1.3
+### Added
+### Changed
 - Breaking: `ok` in FinalReply is now a Boolean discriminator.
 
 ### Fixed
+- Handle a bug where the Idris reply length-header doesn’t match the actual message length on Windows.
 
 ## v0.1.2
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ if (reply.ok) {
   console.warn(reply.err)
 }
 
-// Close the client
-client.close()
+// Close the process
 idrisProc.kill()
 ```
 
@@ -35,7 +34,9 @@ It’s primarily intended to serve as the foundation for my [VSCode extension](h
 Types are great documentation, and I’ve typed all of the s-expressions that the IDE returns in TypeScript. As the IDE protocol documentation is a bit spare, hopefully this will be of help to anyone implementing something similar in the future.
 
 ## Status
-It’s been tested and is working on Idris 1.3.2, on some Linux distributions. When I can get Idris 2 to compile, it will hopefully be extended to that (as far as I understand, the protocol should be backwards compatible).
+It should work with Idris 1.3.X on all OSes.
+
+Idris 2 compatability is being actively worked on, but at the moment, most IDE commands have not been implemented in v2, so it’s still not very usable.
 
 If you experience any problems on other versions or OSes, please raise an issue. Confirming compatability should be as simple as running the tests.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idris-ide-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A library for talking to the Idris IDE.",
   "keywords": [
     "idris"


### PR DESCRIPTION
## v0.1.3
### Added
### Changed
- Breaking: `ok` in FinalReply is now a Boolean discriminator.

### Fixed
- Handle a bug where the Idris reply length-header doesn’t match the actual message length on Windows.
