### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 ## Unreleased
 ### Added
+### Changed
+### Fixed
+
+## v0.1.4
+### Added
 - Added a listening flag to the client, so it can stop listening before closing, to handle Idris2 printing invalid messages on exit.
 ### Changed
 - A few workarounds have been added to the reply-parser to handle Idris 2, version 0.2.1.
 ### Fixed
+- Cover the case where :add-clause returns an error.
 
 ## v0.1.3
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idris-ide-client",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A library for talking to the Idris IDE.",
   "keywords": [
     "idris"


### PR DESCRIPTION
## v0.1.4
### Added
- Added a listening flag to the client, so it can stop listening before closing, to handle Idris2 printing invalid messages on exit.
### Changed
- A few workarounds have been added to the reply-parser to handle Idris 2, version 0.2.1.
### Fixed
- Cover the case where :add-clause returns an error.