### PR TITLE
Gd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Unreleased
 ### Added
+- Added the new Idris2-specific commands :generate-def, :generate-def-next and :proof-search-next.
 ### Changed
+- The client now keeps track of the protocol version, and some requests are serialised differently depending on the version.
 ### Fixed
+- Fixed a bug where the :version request didn't work with Idris2 because of a breaking change in the protocol.
 
 ## v0.1.4
 ### Added

--- a/src/client.ts
+++ b/src/client.ts
@@ -197,6 +197,16 @@ export class IdrisClient {
     return this.makeReq(req).then((r) => r as FinalReply.DocsFor)
   }
 
+  /**
+   * Returns a reply with an attempted solution for the given declaration.
+   *
+   * Returns an error if there is no function declaration on the line arg. It
+   * returns the same not-found error if it is partially-defined.
+   * If the function is already completely defined (all cases handled), it will
+   * return a different error.
+   *
+   * The name parameter doesn’t appear to make any difference.
+   */
   public generateDef(line: number, name: string): Promise<any> {
     const id = ++this.reqCounter
     const req: Request.GenerateDef = { id, line, name, type: ":generate-def" }

--- a/src/client.ts
+++ b/src/client.ts
@@ -197,6 +197,12 @@ export class IdrisClient {
     return this.makeReq(req).then((r) => r as FinalReply.DocsFor)
   }
 
+  public generateDef(line: number, name: string): Promise<any> {
+    const id = ++this.reqCounter
+    const req: Request.GenerateDef = { id, line, name, type: ":generate-def" }
+    return this.makeReq(req)
+  }
+
   /**
    * Returns a reply containing the a string representing the result of
    * interpreting the input, with metadata. Also emits `OutputReply`s with

--- a/src/client.ts
+++ b/src/client.ts
@@ -240,7 +240,7 @@ export class IdrisClient {
    * request. If there is a failed generate-def, generate-def-next will continue
    * producing output for the last _successful_ one.
    *
-   * Returns an error when it runs out of possible solutions. If no generate-def
+   * Returns an error if it runs out of possible solutions. If no generate-def
    * requests have been made, it will also report out of solutions.
    *
    * This command is Idris 2 only, and will return an unrecognised error if
@@ -348,12 +348,13 @@ export class IdrisClient {
 
   /**
    * Returns a reply containing an attempt to solve a metavariable given its
-   * current scope.
+   * current scope. The hole name should omit the ?.
    *
    * It is unclear how the hints argument works. The protocol documentation describes
    * it as ‘possibly-empty list of additional things to try while searching’.
    *
-   * Always successful — is an empty string if no solution is found.
+   * With Idris 1, always successful — is an empty string if no solution is found.
+   * Can fail with Idris 2 if the name isn’t found or if it’s not a hole.
    */
   public proofSearch(
     name: string,
@@ -372,12 +373,23 @@ export class IdrisClient {
   }
 
   /**
-   * TODO!
+   * Returns a reply with the next attempted solution for the last proof-search
+   * request. If there is a failed proof-search, proof-search-next will continue
+   * producing output for the last _successful_ one.
+   *
+   * Returns an error if it runs out of possible solutions. If no proof-search
+   * requests have been made, it will also report out of solutions.
+   *
+   * This command is Idris 2 only, and will return an unrecognised error if
+   * sent to Idris 1.
+   *
+   * The Idris 2 process keeps track of the definition generation state, the
+   * client does track any state.
    */
-  public proofSearchNext(): Promise<any> {
+  public proofSearchNext(): Promise<FinalReply.ProofSearch> {
     const id = ++this.reqCounter
     const req: Request.ProofSearchNext = { id, type: ":proof-search-next" }
-    return this.makeReq(req)
+    return this.makeReq(req).then((r) => r as FinalReply.ProofSearch)
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -222,6 +222,9 @@ export class IdrisClient {
    * return a different error.
    *
    * The name parameter doesn’t appear to make any difference.
+   *
+   * This command is Idris 2 only, and will return an unrecognised error if
+   * sent to Idris 1.
    */
   public generateDef(
     line: number,
@@ -233,12 +236,23 @@ export class IdrisClient {
   }
 
   /**
-   * TODO!
+   * Returns a reply with the next attempted solution for the last generate-def
+   * request. If there is a failed generate-def, generate-def-next will continue
+   * producing output for the last _successful_ one.
+   *
+   * Returns an error when it runs out of possible solutions. If no generate-def
+   * requests have been made, it will also report out of solutions.
+   *
+   * This command is Idris 2 only, and will return an unrecognised error if
+   * sent to Idris 1.
+   *
+   * The Idris 2 process keeps track of the definition generation state, the
+   * client does track any state.
    */
-  public generateDefNext(): Promise<any> {
+  public generateDefNext(): Promise<FinalReply.GenerateDef> {
     const id = ++this.reqCounter
     const req: Request.GenerateDefNext = { id, type: ":generate-def-next" }
-    return this.makeReq(req)
+    return this.makeReq(req).then((r) => r as FinalReply.GenerateDef)
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,16 +17,14 @@ import { spawn } from "child_process"
 
 const idrisProc = spawn("idris2", ["--ide-mode"])
 const client = new IdrisClient(idrisProc.stdin, idrisProc.stdout, {
-  debug: false,
+  debug: true,
 })
 
-client.loadFile("temp.idr").then(() => {
+client.loadFile("../temp.idr").then(() => {
   client
-    // .generateDef(5, "append")
-    // .then(console.log)
-    // .then(() => client.version())
-
-    .version()
+    .generateDef(5, "append")
+    .then(console.log)
+    .then(() => client.generateDefNext())
     .then(console.log)
     .then(() => idrisProc.kill())
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,18 @@ export {
 } from "./reply"
 export { Request } from "./request"
 export { Decor } from "./s-exps"
+
+import { IdrisClient } from "./client"
+import { spawn } from "child_process"
+
+const idrisProc = spawn("idris2", ["--ide-mode"])
+const client = new IdrisClient(idrisProc.stdin, idrisProc.stdout, {
+  debug: true,
+})
+
+client.loadFile("temp.idr").then(() => {
+  client
+    .generateDef(5, "append")
+    .then(console.log)
+    .then(() => idrisProc.kill())
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,9 +22,15 @@ const client = new IdrisClient(idrisProc.stdin, idrisProc.stdout, {
 
 client.loadFile("../temp.idr").then(() => {
   client
-    .generateDef(5, "append")
+    .proofSearch("blue_rhs", 10, [])
     .then(console.log)
-    .then(() => client.generateDefNext())
+    .then(() => client.proofSearchNext())
+    .then(console.log)
+    .then(() => client.proofSearchNext())
+    .then(console.log)
+    .then(() => client.proofSearch("blue", 8, []))
+    .then(console.log)
+    .then(() => client.proofSearchNext())
     .then(console.log)
     .then(() => idrisProc.kill())
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,26 +11,3 @@ export {
 } from "./reply"
 export { Request } from "./request"
 export { Decor } from "./s-exps"
-
-import { IdrisClient } from "./client"
-import { spawn } from "child_process"
-
-const idrisProc = spawn("idris2", ["--ide-mode"])
-const client = new IdrisClient(idrisProc.stdin, idrisProc.stdout, {
-  debug: true,
-})
-
-client.loadFile("../temp.idr").then(() => {
-  client
-    .proofSearch("blue_rhs", 10, [])
-    .then(console.log)
-    .then(() => client.proofSearchNext())
-    .then(console.log)
-    .then(() => client.proofSearchNext())
-    .then(console.log)
-    .then(() => client.proofSearch("blue", 8, []))
-    .then(console.log)
-    .then(() => client.proofSearchNext())
-    .then(console.log)
-    .then(() => idrisProc.kill())
-})

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,12 +17,16 @@ import { spawn } from "child_process"
 
 const idrisProc = spawn("idris2", ["--ide-mode"])
 const client = new IdrisClient(idrisProc.stdin, idrisProc.stdout, {
-  debug: true,
+  debug: false,
 })
 
 client.loadFile("temp.idr").then(() => {
   client
-    .generateDef(5, "append")
+    // .generateDef(5, "append")
+    // .then(console.log)
+    // .then(() => client.version())
+
+    .version()
     .then(console.log)
     .then(() => idrisProc.kill())
 })

--- a/src/parser/reply-parser.ts
+++ b/src/parser/reply-parser.ts
@@ -42,6 +42,7 @@ export const parseReply = (expr: RootExpr, requestType: RequestType): Reply => {
         case ":docs-for":
           return intoFinalReplyDocsFor(payload as S_Exp.DocsFor, id)
         case ":generate-def":
+        case ":generate-def-next":
           return intoFinalReplyGenerateDef(payload as S_Exp.GenerateDef, id)
         case ":interpret":
           return intoFinalReplyInterpret(payload as S_Exp.Interpret, id)
@@ -74,6 +75,7 @@ export const parseReply = (expr: RootExpr, requestType: RequestType): Reply => {
         case ":who-calls":
           return intoFinalReplyWhoCalls(payload as S_Exp.WhoCalls, id)
         default:
+          console.log("!!!", payload, "???")
           throw "Unreachable."
       }
     case ":set-prompt":

--- a/src/parser/reply-parser.ts
+++ b/src/parser/reply-parser.ts
@@ -76,7 +76,6 @@ export const parseReply = (expr: RootExpr, requestType: RequestType): Reply => {
         case ":who-calls":
           return intoFinalReplyWhoCalls(payload as S_Exp.WhoCalls, id)
         default:
-          console.log("!!!", payload, "???")
           throw "Unreachable."
       }
     case ":set-prompt":

--- a/src/parser/reply-parser.ts
+++ b/src/parser/reply-parser.ts
@@ -21,7 +21,7 @@ export const parseReply = (expr: RootExpr, requestType: RequestType): Reply => {
     case ":output":
       return intoOutputReply(payload as S_Exp.Output, id)
     case ":protocol-version":
-      return intoInfoReplyVersion(payload as S_Exp.ProtocolVersion, id)
+      return intoInfoReplyProtocolVersion(payload as S_Exp.ProtocolVersion, id)
     case ":return":
       switch (requestType) {
         case ":add-clause":
@@ -174,7 +174,7 @@ const intoInfoReplySetPrompt = (
   type: ":set-prompt",
 })
 
-const intoInfoReplyVersion = (
+const intoInfoReplyProtocolVersion = (
   payload: S_Exp.ProtocolVersion,
   id: number
 ): InfoReply.Version => ({

--- a/src/parser/reply-parser.ts
+++ b/src/parser/reply-parser.ts
@@ -389,12 +389,22 @@ const intoFinalReplyGenerateDef = (
   payload: S_Exp.GenerateDef,
   id: number
 ): FinalReply.GenerateDef => {
-  const [_ok, def] = payload
-  return {
-    def,
-    id,
-    ok: true,
-    type: ":return",
+  if (S_Exp.isOkGenerateDef(payload)) {
+    const [_ok, def] = payload
+    return {
+      def,
+      id,
+      ok: true,
+      type: ":return",
+    }
+  } else {
+    const [_err, err] = payload
+    return {
+      err,
+      id,
+      ok: false,
+      type: ":return",
+    }
   }
 }
 

--- a/src/parser/reply-parser.ts
+++ b/src/parser/reply-parser.ts
@@ -62,6 +62,7 @@ export const parseReply = (expr: RootExpr, requestType: RequestType): Reply => {
             id
           )
         case ":proof-search":
+        case ":proof-search-next":
           return intoFinalReplyProofSearch(payload as S_Exp.ProofSearch, id)
         case ":repl-completions":
           return intoFinalReplyReplCompletions(
@@ -578,12 +579,22 @@ const intoFinalReplyProofSearch = (
   payload: S_Exp.ProofSearch,
   id: number
 ): FinalReply.ProofSearch => {
-  const [_ok, solution] = payload
-  return {
-    id,
-    ok: true,
-    solution,
-    type: ":return",
+  if (S_Exp.isOkProofSearch(payload)) {
+    const [_ok, solution] = payload
+    return {
+      id,
+      ok: true,
+      solution,
+      type: ":return",
+    }
+  } else {
+    const [_err, msg] = payload
+    return {
+      err: msg,
+      id,
+      ok: false,
+      type: ":return",
+    }
   }
 }
 

--- a/src/parser/reply-parser.ts
+++ b/src/parser/reply-parser.ts
@@ -41,6 +41,8 @@ export const parseReply = (expr: RootExpr, requestType: RequestType): Reply => {
           return intoFinalReplyCaseSplit(payload as S_Exp.CaseSplit, id)
         case ":docs-for":
           return intoFinalReplyDocsFor(payload as S_Exp.DocsFor, id)
+        case ":generate-def":
+          return intoFinalReplyGenerateDef(payload as S_Exp.GenerateDef, id)
         case ":interpret":
           return intoFinalReplyInterpret(payload as S_Exp.Interpret, id)
         case ":load-file":
@@ -380,6 +382,19 @@ const intoFinalReplyDocsFor = (
       ok: false,
       type: ":return",
     }
+  }
+}
+
+const intoFinalReplyGenerateDef = (
+  payload: S_Exp.GenerateDef,
+  id: number
+): FinalReply.GenerateDef => {
+  const [_ok, def] = payload
+  return {
+    def,
+    id,
+    ok: true,
+    type: ":return",
   }
 }
 

--- a/src/reply.ts
+++ b/src/reply.ts
@@ -168,12 +168,14 @@ export namespace FinalReply {
       }
     | { err: string; id: number; ok: false; type: ":return" }
 
-  export type GenerateDef = {
-    def: string
-    id: number
-    ok: true
-    type: ":return"
-  }
+  export type GenerateDef =
+    | {
+        def: string
+        id: number
+        ok: true
+        type: ":return"
+      }
+    | { err: string; id: number; ok: false; type: ":return" }
 
   /**
    * If part of the input can be interpreted, it will be an error, but with metadata.

--- a/src/reply.ts
+++ b/src/reply.ts
@@ -245,12 +245,14 @@ export namespace FinalReply {
       }
     | { err: string; id: number; ok: false; type: ":return" }
 
-  export type ProofSearch = {
-    id: number
-    ok: true
-    solution: string
-    type: ":return"
-  }
+  export type ProofSearch =
+    | {
+        id: number
+        ok: true
+        solution: string
+        type: ":return"
+      }
+    | { err: string; id: number; ok: false; type: ":return" }
 
   /**
    * This reply omits an additional element that seems to always be an empty string.

--- a/src/reply.ts
+++ b/src/reply.ts
@@ -168,6 +168,13 @@ export namespace FinalReply {
       }
     | { err: string; id: number; ok: false; type: ":return" }
 
+  export type GenerateDef = {
+    def: string
+    id: number
+    ok: true
+    type: ":return"
+  }
+
   /**
    * If part of the input can be interpreted, it will be an error, but with metadata.
    */
@@ -290,6 +297,7 @@ export type Reply =
   | FinalReply.CallsWho
   | FinalReply.CaseSplit
   | FinalReply.DocsFor
+  | FinalReply.GenerateDef
   | FinalReply.Interpret
   | FinalReply.LoadFile
   | FinalReply.MakeCase

--- a/src/request.ts
+++ b/src/request.ts
@@ -8,6 +8,7 @@ export type RequestType =
   | ":case-split"
   | ":docs-for"
   // | ":elaborate-term"
+  | ":generate-def"
   // | ":hide-term-implicits"
   | ":interpret"
   | ":load-file"
@@ -76,6 +77,13 @@ export namespace Request {
     mode: DocMode
     name: string
     type: ":docs-for"
+  }
+
+  export interface GenerateDef extends RequestBase {
+    id: number
+    line: number
+    name: string
+    type: ":generate-def"
   }
 
   export interface Interpret extends RequestBase {
@@ -163,6 +171,7 @@ export type Request =
   | Request.CallsWho
   | Request.CaseSplit
   | Request.DocsFor
+  | Request.GenerateDef
   | Request.Interpret
   | Request.LoadFile
   | Request.MakeCase
@@ -186,6 +195,7 @@ const serialiseArgs = (req: Request): string => {
     case ":add-clause":
     case ":add-missing":
     case ":case-split":
+    case ":generate-def":
     case ":make-case":
     case ":make-lemma":
     case ":make-with":

--- a/src/s-exps.ts
+++ b/src/s-exps.ts
@@ -117,7 +117,12 @@ export namespace S_Exp {
   export const isOkDocsFor = (payload: DocsFor): payload is DocsForOk =>
     payload[0] === ":ok"
 
-  export type GenerateDef = [":ok", string]
+  export type GenerateDefOk = [":ok", string]
+  export type GenerateDefErr = [":error", string]
+  export type GenerateDef = GenerateDefOk | GenerateDefErr
+  export const isOkGenerateDef = (
+    payload: GenerateDef
+  ): payload is GenerateDefOk => payload[0] === ":ok"
 
   export type InterpretOk = [":ok", string, MsgMetadataExpr[]]
   // If it can parse some of the input, it returns metadata.

--- a/src/s-exps.ts
+++ b/src/s-exps.ts
@@ -167,7 +167,12 @@ export namespace S_Exp {
     payload: PrintDefinition
   ): payload is PrintDefinitionOk => payload[0] === ":ok"
 
-  export type ProofSearch = [":ok", string]
+  export type ProofSearchOk = [":ok", string]
+  export type ProofSearchErr = [":error", string]
+  export type ProofSearch = ProofSearchOk | ProofSearchErr
+  export const isOkProofSearch = (
+    payload: ProofSearch
+  ): payload is ProofSearchOk => payload[0] === ":ok"
 
   export type ReplCompletions = [":ok", [string[], ""]]
 

--- a/src/s-exps.ts
+++ b/src/s-exps.ts
@@ -117,6 +117,8 @@ export namespace S_Exp {
   export const isOkDocsFor = (payload: DocsFor): payload is DocsForOk =>
     payload[0] === ":ok"
 
+  export type GenerateDef = [":ok", string]
+
   export type InterpretOk = [":ok", string, MsgMetadataExpr[]]
   // If it can parse some of the input, it returns metadata.
   export type InterpretErr =

--- a/test/client/expected.ts
+++ b/test/client/expected.ts
@@ -280,6 +280,13 @@ export const docsFor: FinalReply.DocsFor = {
   type: ":return",
 }
 
+export const generateDef: FinalReply.GenerateDef = {
+  def: "append [] ys = ys\nappend (x :: xs) ys = x :: append xs ys",
+  id: 19,
+  ok: true,
+  type: ":return",
+}
+
 export const interpret: FinalReply.Interpret = {
   result: "4 : Integer",
   metadata: [

--- a/test/client/expected.ts
+++ b/test/client/expected.ts
@@ -287,6 +287,13 @@ export const generateDef: FinalReply.GenerateDef = {
   type: ":return",
 }
 
+export const generateDefNext: FinalReply.GenerateDef = {
+  def: "append [] ys = ys\nappend (x :: xs) [] = x :: append xs []\nappend (x :: xs) (y :: ys) = x :: append xs (y :: ys)",
+  id: 21,
+  ok: true,
+  type: ":return",
+}
+
 export const interpret: FinalReply.Interpret = {
   result: "4 : Integer",
   metadata: [

--- a/test/client/expected.ts
+++ b/test/client/expected.ts
@@ -280,20 +280,6 @@ export const docsFor: FinalReply.DocsFor = {
   type: ":return",
 }
 
-export const generateDef: FinalReply.GenerateDef = {
-  def: "append [] ys = ys\nappend (x :: xs) ys = x :: append xs ys",
-  id: 20,
-  ok: true,
-  type: ":return",
-}
-
-export const generateDefNext: FinalReply.GenerateDef = {
-  def: "append [] ys = ys\nappend (x :: xs) [] = x :: append xs []\nappend (x :: xs) (y :: ys) = x :: append xs (y :: ys)",
-  id: 21,
-  ok: true,
-  type: ":return",
-}
-
 export const interpret: FinalReply.Interpret = {
   result: "4 : Integer",
   metadata: [
@@ -780,5 +766,28 @@ export const whoCalls: FinalReply.WhoCalls = {
   ],
   id: 19,
   ok: true,
+  type: ":return",
+}
+
+// Idris 2 only.
+export const generateDef: FinalReply.GenerateDef = {
+  def: "append [] ys = ys\nappend (x :: xs) ys = x :: append xs ys",
+  id: 20,
+  ok: true,
+  type: ":return",
+}
+
+export const generateDefNext: FinalReply.GenerateDef = {
+  def:
+    "append [] ys = ys\nappend (x :: xs) [] = x :: append xs []\nappend (x :: xs) (y :: ys) = x :: append xs (y :: ys)",
+  id: 21,
+  ok: true,
+  type: ":return",
+}
+
+export const proofSearchNext: FinalReply.ProofSearch = {
+  id: 22,
+  ok: true,
+  solution: "1",
   type: ":return",
 }

--- a/test/client/expected.ts
+++ b/test/client/expected.ts
@@ -282,7 +282,7 @@ export const docsFor: FinalReply.DocsFor = {
 
 export const generateDef: FinalReply.GenerateDef = {
   def: "append [] ys = ys\nappend (x :: xs) ys = x :: append xs ys",
-  id: 19,
+  id: 20,
   ok: true,
   type: ":return",
 }

--- a/test/client/unimplemented.ts
+++ b/test/client/unimplemented.ts
@@ -152,7 +152,7 @@ export const typeOf: FinalReply.TypeOf = {
 export const whoCalls: FinalReply.WhoCalls = {
   callee: null,
   references: [],
-  id: 18, // one lower, until version can be implemented
+  id: 19,
   ok: true,
   type: ":return",
 }

--- a/test/client/unimplemented.ts
+++ b/test/client/unimplemented.ts
@@ -64,6 +64,14 @@ export const metavariables: FinalReply.Metavariables = {
     {
       metavariable: {
         metadata: [],
+        name: "Main.append",
+        type: "Vect n a -> Vect m a -> Vect (plus n m) a",
+      },
+      premises: [],
+    },
+    {
+      metavariable: {
+        metadata: [],
         name: "Main.f",
         type: "Cat -> String",
       },

--- a/test/client/v2Client.test.ts
+++ b/test/client/v2Client.test.ts
@@ -126,12 +126,10 @@ describe("Running the client commands", () => {
     assert.deepEqual(actual, unimplemented.typeOf)
   })
 
-  // Unimplemented — command completely unrecognised
-  // (:return (:error "Unrecognised command: ((:version) 18)") 17)
   it("returns the expected result for :version", async () => {
-    // const actual = await ic.version()
+    const actual = await ic.version()
     // We don’t want to tie the test to an actual version.
-    // assert.isTrue(actual.ok)
+    assert.isTrue(actual.ok)
   })
 
   // Unimplemented

--- a/test/client/v2Client.test.ts
+++ b/test/client/v2Client.test.ts
@@ -141,14 +141,19 @@ describe("Running the client commands", () => {
 
   // New V2 commands
 
-  it("returns the expected result for :generaate-def", async () => {
+  it("returns the expected result for :generate-def", async () => {
     const actual = await ic.generateDef(23, "append")
     assert.deepEqual(actual, expected.generateDef)
   })
 
-  it("returns the expected result for :generaate-def-next", async () => {
+  it("returns the expected result for :generate-def-next", async () => {
     const actual = await ic.generateDefNext()
     assert.deepEqual(actual, expected.generateDefNext)
+  })
+
+  it("returns the expected result for :proof-search-next", async () => {
+    const actual = await ic.proofSearchNext()
+    assert.deepEqual(actual, expected.proofSearchNext)
   })
 
   after(() => {

--- a/test/client/v2Client.test.ts
+++ b/test/client/v2Client.test.ts
@@ -24,7 +24,7 @@ describe("Running the client commands", () => {
   }).timeout(10000)
 
   it("returns the expected result for :add-clause.", async () => {
-    const actual = await ic.addClause("f", 5)
+    const actual = await ic.addClause("f", 7)
     assert.deepEqual(actual, expected.addClause)
   })
 
@@ -32,7 +32,7 @@ describe("Running the client commands", () => {
   // (:write-string "add-missing: command not yet implemented. Hopefully soon!" 3)
   // Also, how will this work if it won’t load the file with missing cases?
   it("returns the expected result for :add-missing.", async () => {
-    const actual = await ic.addMissing("getName", 7)
+    const actual = await ic.addMissing("getName", 9)
     assert.deepEqual(actual, unimplemented.addMissing)
   })
 
@@ -58,7 +58,7 @@ describe("Running the client commands", () => {
   })
 
   it("returns the expected result for :case-split", async () => {
-    const actual = await ic.caseSplit("n", 13)
+    const actual = await ic.caseSplit("n", 15)
     assert.deepEqual(actual, expected.caseSplitV2)
   })
 
@@ -77,19 +77,19 @@ describe("Running the client commands", () => {
   })
 
   it("returns the expected result for :make-case", async () => {
-    const actual = await ic.makeCase("g_rhs", 16)
+    const actual = await ic.makeCase("g_rhs", 18)
     assert.deepEqual(actual, expected.makeCaseV2)
   })
 
   // Partially implemented — Broken
   // (:return (:ok "g_rhs : Bool -> Nat -> String\ng_rhs b n") 11)
   it("returns the expected result for :make-lemma", async () => {
-    const actual = await ic.makeLemma("g_rhs", 16)
+    const actual = await ic.makeLemma("g_rhs", 18)
     assert.deepEqual(actual, unimplemented.makeLemma)
   })
 
   it("returns the expected result for :make-with", async () => {
-    const actual = await ic.makeWith("g_rhs", 16)
+    const actual = await ic.makeWith("g_rhs", 18)
     assert.deepEqual(actual, expected.makeWithV2)
   })
 
@@ -107,7 +107,7 @@ describe("Running the client commands", () => {
   })
 
   it("returns the expected result for :proof-search", async () => {
-    const actual = await ic.proofSearch("n_rhs", 19, [])
+    const actual = await ic.proofSearch("n_rhs", 21, [])
     assert.deepEqual(actual, expected.proofSearch)
   })
 
@@ -139,6 +139,13 @@ describe("Running the client commands", () => {
   it("returns the expected result for :who-calls", async () => {
     const actual = await ic.whoCalls("Cat")
     assert.deepEqual(actual, unimplemented.whoCalls)
+  })
+
+  // New V2 commands
+
+  it("returns the expected result for :generaate-def", async () => {
+    const actual = await ic.generateDef(23, "append")
+    assert.deepEqual(actual, expected.generateDef)
   })
 
   after(() => {

--- a/test/client/v2Client.test.ts
+++ b/test/client/v2Client.test.ts
@@ -146,6 +146,11 @@ describe("Running the client commands", () => {
     assert.deepEqual(actual, expected.generateDef)
   })
 
+  it("returns the expected result for :generaate-def-next", async () => {
+    const actual = await ic.generateDefNext()
+    assert.deepEqual(actual, expected.generateDefNext)
+  })
+
   after(() => {
     ic.close()
     proc.kill()

--- a/test/parser/generate-def-next.test.ts
+++ b/test/parser/generate-def-next.test.ts
@@ -5,6 +5,7 @@ import { deserialise } from "../../src/parser/expr-parser"
 import { lex } from "../../src/parser/lexer"
 import { S_Exp, RootExpr } from "../../src/s-exps"
 
+// Idris 2 only.
 describe("Parsing :generate-def reply", () => {
   it("can parse a success sexp.", () => {
     const sexp = `(:return (:ok "append [] ys = ys\nappend (x :: xs) [] = x :: append xs []\nappend (x :: xs) (y :: ys) = x :: append xs (y :: ys)") 3)`
@@ -31,7 +32,7 @@ describe("Parsing :generate-def reply", () => {
 
   it("can parse a failure sexp.", () => {
     const sexp = `(:return (:error "No more results") 16)`
-    const payload: S_Exp.GenerateDefErr = [":error", "No more results"]
+    const payload: S_Exp.GenerateDef = [":error", "No more results"]
     const rootExpr: RootExpr = [":return", payload, 16]
     const expected: FinalReply.GenerateDef = {
       err: "No more results",

--- a/test/parser/generate-def-next.ts
+++ b/test/parser/generate-def-next.ts
@@ -1,0 +1,50 @@
+import { assert } from "chai"
+import { parseReply } from "../../src/parser"
+import { FinalReply } from "../../src/reply"
+import { deserialise } from "../../src/parser/expr-parser"
+import { lex } from "../../src/parser/lexer"
+import { S_Exp, RootExpr } from "../../src/s-exps"
+
+describe("Parsing :generate-def reply", () => {
+  it("can parse a success sexp.", () => {
+    const sexp = `(:return (:ok "append [] ys = ys\nappend (x :: xs) [] = x :: append xs []\nappend (x :: xs) (y :: ys) = x :: append xs (y :: ys)") 3)`
+    const payload: S_Exp.GenerateDef = [
+      ":ok",
+      "append [] ys = ys\nappend (x :: xs) [] = x :: append xs []\nappend (x :: xs) (y :: ys) = x :: append xs (y :: ys)",
+    ]
+    const rootExpr: RootExpr = [":return", payload, 3]
+    const expected: FinalReply.GenerateDef = {
+      def:
+        "append [] ys = ys\nappend (x :: xs) [] = x :: append xs []\nappend (x :: xs) (y :: ys) = x :: append xs (y :: ys)",
+      id: 3,
+      ok: true,
+      type: ":return",
+    }
+
+    const tokens = lex(sexp)
+    const exprs = deserialise(tokens)[0] as RootExpr
+    assert.deepEqual(exprs, rootExpr)
+
+    const parsed = parseReply(rootExpr, ":generate-def-next")
+    assert.deepEqual(parsed, expected)
+  })
+
+  it("can parse a failure sexp.", () => {
+    const sexp = `(:return (:error "No more results") 16)`
+    const payload: S_Exp.GenerateDefErr = [":error", "No more results"]
+    const rootExpr: RootExpr = [":return", payload, 16]
+    const expected: FinalReply.GenerateDef = {
+      err: "No more results",
+      id: 16,
+      ok: false,
+      type: ":return",
+    }
+
+    const tokens = lex(sexp)
+    const exprs = deserialise(tokens)[0] as RootExpr
+    assert.deepEqual(exprs, rootExpr)
+
+    const parsed = parseReply(rootExpr, ":generate-def-next")
+    assert.deepEqual(parsed, expected)
+  })
+})

--- a/test/parser/generate-def.test.ts
+++ b/test/parser/generate-def.test.ts
@@ -5,6 +5,7 @@ import { deserialise } from "../../src/parser/expr-parser"
 import { lex } from "../../src/parser/lexer"
 import { S_Exp, RootExpr } from "../../src/s-exps"
 
+// Idris 2 only.
 describe("Parsing :generate-def reply", () => {
   it("can parse a success sexp.", () => {
     const sexp = `(:return (:ok "append [] ys = ys\nappend (x :: xs) ys = x :: append xs ys") 2)`

--- a/test/parser/generate-def.test.ts
+++ b/test/parser/generate-def.test.ts
@@ -1,0 +1,71 @@
+import { assert } from "chai"
+import { parseReply } from "../../src/parser"
+import { FinalReply } from "../../src/reply"
+import { deserialise } from "../../src/parser/expr-parser"
+import { lex } from "../../src/parser/lexer"
+import { S_Exp, RootExpr } from "../../src/s-exps"
+
+describe("Parsing :generate-def reply", () => {
+  it("can parse a success sexp.", () => {
+    const sexp = `(:return (:ok "append [] ys = ys\nappend (x :: xs) ys = x :: append xs ys") 2)`
+    const payload: S_Exp.GenerateDef = [
+      ":ok",
+      "append [] ys = ys\nappend (x :: xs) ys = x :: append xs ys",
+    ]
+    const rootExpr: RootExpr = [":return", payload, 2]
+    const expected: FinalReply.GenerateDef = {
+      def: "append [] ys = ys\nappend (x :: xs) ys = x :: append xs ys",
+      id: 2,
+      ok: true,
+      type: ":return",
+    }
+
+    const tokens = lex(sexp)
+    const exprs = deserialise(tokens)[0] as RootExpr
+    assert.deepEqual(exprs, rootExpr)
+
+    const parsed = parseReply(rootExpr, ":generate-def")
+    assert.deepEqual(parsed, expected)
+  })
+
+  it("can parse a not-found failure sexp.", () => {
+    const sexp = `(:return (:error "Can't find declaration for append on line 5") 2)`
+    const payload: S_Exp.GenerateDefErr = [
+      ":error",
+      "Can't find declaration for append on line 5",
+    ]
+    const rootExpr: RootExpr = [":return", payload, 2]
+    const expected: FinalReply.GenerateDef = {
+      err: "Can't find declaration for append on line 5",
+      id: 2,
+      ok: false,
+      type: ":return",
+    }
+
+    const tokens = lex(sexp)
+    const exprs = deserialise(tokens)[0] as RootExpr
+    assert.deepEqual(exprs, rootExpr)
+
+    const parsed = parseReply(rootExpr, ":generate-def")
+    assert.deepEqual(parsed, expected)
+  })
+
+  it("can parse a already-defined failure sexp.", () => {
+    const sexp = `(:return (:error "Already defined") 2)`
+    const payload: S_Exp.GenerateDefErr = [":error", "Already defined"]
+    const rootExpr: RootExpr = [":return", payload, 2]
+    const expected: FinalReply.GenerateDef = {
+      err: "Already defined",
+      id: 2,
+      ok: false,
+      type: ":return",
+    }
+
+    const tokens = lex(sexp)
+    const exprs = deserialise(tokens)[0] as RootExpr
+    assert.deepEqual(exprs, rootExpr)
+
+    const parsed = parseReply(rootExpr, ":generate-def")
+    assert.deepEqual(parsed, expected)
+  })
+})

--- a/test/parser/proof-search-next.test.ts
+++ b/test/parser/proof-search-next.test.ts
@@ -5,7 +5,8 @@ import { deserialise } from "../../src/parser/expr-parser"
 import { lex } from "../../src/parser/lexer"
 import { RootExpr, S_Exp } from "../../src/s-exps"
 
-describe("Parsing :proof-search reply", () => {
+// Idris 2 only.
+describe("Parsing :proof-search-next reply", () => {
   it("can parse a success sexp.", () => {
     const sexp = `(:return (:ok "0") 2)`
     const payload: S_Exp.ProofSearch = [":ok", "0"]
@@ -25,14 +26,13 @@ describe("Parsing :proof-search reply", () => {
     assert.deepEqual(parsed, expected)
   })
 
-  // Idris 2 only.
   it("can parse a failure sexp.", () => {
-    const sexp = `(:return (:error "Not a searchable hole") 2)`
-    const payload: S_Exp.ProofSearch = [":error", "Not a searchable hole"]
-    const rootExpr: RootExpr = [":return", payload, 2]
+    const sexp = `(:return (:error "No more results") 4)`
+    const payload: S_Exp.ProofSearch = [":error", "No more results"]
+    const rootExpr: RootExpr = [":return", payload, 4]
     const expected: FinalReply.ProofSearch = {
-      err: "Not a searchable hole",
-      id: 2,
+      err: "No more results",
+      id: 4,
       ok: false,
       type: ":return",
     }
@@ -41,7 +41,7 @@ describe("Parsing :proof-search reply", () => {
     const exprs = deserialise(tokens)[0] as RootExpr
     assert.deepEqual(exprs, rootExpr)
 
-    const parsed = parseReply(rootExpr, ":proof-search")
+    const parsed = parseReply(rootExpr, ":proof-search-next")
     assert.deepEqual(parsed, expected)
   })
 })

--- a/test/resources/test-v2.idr
+++ b/test/resources/test-v2.idr
@@ -1,5 +1,7 @@
 module Main
 
+import Data.Vect
+
 data Cat = Cas | Luna | Sherlock
 
 f : (cat: Cat) -> String
@@ -17,3 +19,5 @@ g n b = ?g_rhs
 
 num : Nat
 num = ?n_rhs
+
+append : Vect n a -> Vect m a -> Vect (n + m) a


### PR DESCRIPTION
Adds support for some new Idris2 specific commands. While I was implementing :generate-def-next, I was having trouble getting the IDE to recognise the request, until I realised that the serialisation format was incompatible. In Idris 1, *all* commands were wrapped in an s-expression list with their arguments. In Idris 2, commands without arguments are represented only by a symbol. This is why the :version command didn't work — I had just assumed it wasn't implemented yet but actually it needed a different format.

So that's been fixed, but it meant that I've finally had to introduce branching based on version. That's ok, it was inevitable. For now, it's still managable, but if I have to introduce more conditionals as the v2 protocol diverges further, I might eventually want to have entirely separate request/reply implementations. 

At least the user doesn't need to do anything to set the protocol version, because it's sent automatically by the IDE process as the first (0th) message, so it's easy to set automatically.

_To answer_: will the *-next commands continue working if one has been accepted? (it'll be easier to answer this when I start integrating it into the extension)