### PR TITLE
Put args in normal order

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -227,8 +227,8 @@ export class IdrisClient {
    * sent to Idris 1.
    */
   public generateDef(
-    line: number,
-    name: string
+    name: string,
+    line: number
   ): Promise<FinalReply.GenerateDef> {
     const id = ++this.reqCounter
     const req: Request.GenerateDef = { id, line, name, type: ":generate-def" }

--- a/test/client/v2Client.test.ts
+++ b/test/client/v2Client.test.ts
@@ -142,7 +142,7 @@ describe("Running the client commands", () => {
   // New V2 commands
 
   it("returns the expected result for :generate-def", async () => {
-    const actual = await ic.generateDef(23, "append")
+    const actual = await ic.generateDef("append", 23)
     assert.deepEqual(actual, expected.generateDef)
   })
 


### PR DESCRIPTION
This is a really minor thing, but when I was experimenting with using the new function, I realised that it's line, name when _all_ the other commands are name, line. 

I don't think either ordering is more logical than the other, but I'd prefer to keep it consistent. 