### PR TITLE
type-at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## Unreleased
 ### Added
 - Added the new Idris2-specific commands :generate-def, :generate-def-next and :proof-search-next.
+- Added a typeAt method, which implements the Idris2 :type-of + location command.
 ### Changed
 - The client now keeps track of the protocol version, and some requests are serialised differently depending on the version.
 ### Fixed
-- Fixed a bug where the :version request didn't work with Idris2 because of a breaking change in the protocol.
+- Partially fixed a bug where the :version request didn't work with Idris2 because of a breaking change in the protocol.
 
 ## v0.1.4
 ### Added

--- a/src/client.ts
+++ b/src/client.ts
@@ -405,6 +405,21 @@ export class IdrisClient {
   }
 
   /**
+   * Description - TODO
+   *
+   * Lines and columns are both 1-indexed.
+   */
+  public typeAt(
+    name: string,
+    line: number,
+    column: number
+  ): Promise<FinalReply.TypeAt> {
+    const id = ++this.reqCounter
+    const req: Request.TypeAt = { column, id, line, name, type: ":type-at" }
+    return this.makeReq(req).then((r) => r as FinalReply.TypeAt)
+  }
+
+  /**
    * Returns a reply containing the type of the argument, with metadata.
    *
    * Returns an error object if the argument cannot be found.

--- a/src/client.ts
+++ b/src/client.ts
@@ -405,7 +405,16 @@ export class IdrisClient {
   }
 
   /**
-   * Description - TODO
+   * Returns a reply containing the type of the argument, but does not include
+   * metadata.
+   *
+   * If it finds an identifier at the specified location, it will use that,
+   * regardless of the name supplied.
+   *
+   * If there is no identifier at the location, but there is a top-level
+   * declaration that matches the name, it will return that type.
+   *
+   * Returns an error object if neither the location nor name can be found.
    *
    * Lines and columns are both 1-indexed.
    */

--- a/src/parser/reply-parser.ts
+++ b/src/parser/reply-parser.ts
@@ -69,6 +69,8 @@ export const parseReply = (expr: RootExpr, requestType: RequestType): Reply => {
             payload as S_Exp.ReplCompletions,
             id
           )
+        case ":type-at":
+          return intoFinalReplyTypeAt(payload as S_Exp.TypeAt, id)
         case ":type-of":
           return intoFinalReplyTypeOf(payload as S_Exp.TypeOf, id)
         case ":version":
@@ -610,6 +612,29 @@ const intoFinalReplyReplCompletions = (
     id,
     ok: true,
     type: ":return",
+  }
+}
+
+const intoFinalReplyTypeAt = (
+  payload: S_Exp.TypeAt,
+  id: number
+): FinalReply.TypeAt => {
+  if (S_Exp.isOkTypeAt(payload)) {
+    const [_ok, typeAt] = payload
+    return {
+      id,
+      ok: true,
+      type: ":return",
+      typeAt,
+    }
+  } else {
+    const [_err, msg] = payload
+    return {
+      err: msg,
+      id,
+      ok: false,
+      type: ":return",
+    }
   }
 }
 

--- a/src/reply.ts
+++ b/src/reply.ts
@@ -264,6 +264,15 @@ export namespace FinalReply {
     type: ":return"
   }
 
+  export type TypeAt =
+    | {
+        id: number
+        ok: true
+        type: ":return"
+        typeAt: string
+      }
+    | { err: string; id: number; ok: false; type: ":return" }
+
   export type TypeOf =
     | {
         id: number

--- a/src/request.ts
+++ b/src/request.ts
@@ -23,6 +23,7 @@ export type RequestType =
   | ":proof-search-next"
   | ":repl-completions"
   // | ":show-term-implicits"
+  | ":type-at"
   | ":type-of"
   | ":version"
   | ":who-calls"
@@ -158,6 +159,14 @@ export namespace Request {
     type: ":repl-completions"
   }
 
+  export interface TypeAt extends RequestBase {
+    column: number
+    id: number
+    line: number
+    name: string
+    type: ":type-at"
+  }
+
   export interface TypeOf extends RequestBase {
     id: number
     name: string
@@ -195,6 +204,7 @@ export type Request =
   | Request.ProofSearch
   | Request.ProofSearchNext
   | Request.ReplCompletions
+  | Request.TypeAt
   | Request.TypeOf
   | Request.Version
   | Request.WhoCalls
@@ -234,6 +244,8 @@ const serialiseArgs = (req: Request): string => {
       return `${req.type} ${req.width}`
     case ":proof-search":
       return `${req.type} ${req.line} "${req.name}" (${req.hints.join(" ")})`
+    case ":type-at":
+      return `:type-of "${req.name}" ${req.line} ${req.column}`
     case ":generate-def-next":
     case ":proof-search-next":
     case ":version":

--- a/src/s-exps.ts
+++ b/src/s-exps.ts
@@ -176,6 +176,12 @@ export namespace S_Exp {
 
   export type ReplCompletions = [":ok", [string[], ""]]
 
+  export type TypeAtOk = [":ok", string]
+  export type TypeAtErr = [":error", string]
+  export type TypeAt = TypeAtOk | TypeAtErr
+  export const isOkTypeAt = (payload: TypeAt): payload is TypeAtOk =>
+    payload[0] === ":ok"
+
   export type TypeOfOk = [":ok", string, MsgMetadataExpr[]]
   export type TypeOfErr = [":error", string]
   export type TypeOf = TypeOfOk | TypeOfErr

--- a/test/client/expected.ts
+++ b/test/client/expected.ts
@@ -791,3 +791,10 @@ export const proofSearchNext: FinalReply.ProofSearch = {
   solution: "1",
   type: ":return",
 }
+
+export const typeAt: FinalReply.TypeAt = {
+  id: 23,
+  ok: true,
+  type: ":return",
+  typeAt: "b : Bool",
+}

--- a/test/client/v2Client.test.ts
+++ b/test/client/v2Client.test.ts
@@ -156,6 +156,11 @@ describe("Running the client commands", () => {
     assert.deepEqual(actual, expected.proofSearchNext)
   })
 
+  it("returns the expected result for :type-at", async () => {
+    const actual = await ic.typeAt("b", 18, 5)
+    assert.deepEqual(actual, expected.typeAt)
+  })
+
   after(() => {
     ic.close()
     proc.kill()

--- a/test/parser/type-at.test.ts
+++ b/test/parser/type-at.test.ts
@@ -1,0 +1,52 @@
+import { assert } from "chai"
+import { parseReply } from "../../src/parser"
+import { deserialise } from "../../src/parser/expr-parser"
+import { lex } from "../../src/parser/lexer"
+import { RootExpr, S_Exp } from "../../src/s-exps"
+import { FinalReply } from "../../src/reply"
+
+describe("Parsing :type-of reply", () => {
+  it("can parse a success sexp.", () => {
+    const sexp = `(:return (:ok "b : Bool") 23)`
+    const payload: S_Exp.TypeAtOk = [":ok", "b : Bool"]
+
+    const rootExpr: RootExpr = [":return", payload, 23]
+    const expected: FinalReply.TypeAt = {
+      id: 23,
+      ok: true,
+      type: ":return",
+      typeAt: "b : Bool",
+    }
+
+    const tokens = lex(sexp)
+    const exprs = deserialise(tokens)[0] as RootExpr
+    assert.deepEqual(exprs, rootExpr)
+
+    const parsed = parseReply(rootExpr, ":type-at")
+    assert.deepEqual(parsed, expected)
+  })
+
+  it("can parse a failure sexp", () => {
+    const sexp = `(:return (:error "Undefined name luna. \n\n(interactive):1:1--1:1\n   |\n 1 | 2 * 2\n   | \n") 23)`
+    const payload: S_Exp.TypeAtErr = [
+      ":error",
+      "Undefined name luna. \n\n(interactive):1:1--1:1\n   |\n 1 | 2 * 2\n   | \n",
+    ]
+
+    const rootExpr: RootExpr = [":return", payload, 23]
+    const expected: FinalReply.TypeAt = {
+      err:
+        "Undefined name luna. \n\n(interactive):1:1--1:1\n   |\n 1 | 2 * 2\n   | \n",
+      id: 23,
+      ok: false,
+      type: ":return",
+    }
+
+    const tokens = lex(sexp)
+    const exprs = deserialise(tokens)[0] as RootExpr
+    assert.deepEqual(exprs, rootExpr)
+
+    const parsed = parseReply(rootExpr, ":type-at")
+    assert.deepEqual(parsed, expected)
+  })
+})

--- a/test/resources/test-v2.idr
+++ b/test/resources/test-v2.idr
@@ -21,3 +21,6 @@ num : Nat
 num = ?n_rhs
 
 append : Vect n a -> Vect m a -> Vect (n + m) a
+
+inc : Nat -> Nat
+inc k = S(k)

--- a/test/resources/test-v2.idr
+++ b/test/resources/test-v2.idr
@@ -21,6 +21,3 @@ num : Nat
 num = ?n_rhs
 
 append : Vect n a -> Vect m a -> Vect (n + m) a
-
-inc : Nat -> Nat
-inc k = S(k)


### PR DESCRIPTION
Implements the :typeat functionality, which was recently [updated](https://github.com/idris-lang/Idris2/pull/998). 

From what I can tell, it's existed for a while, but wasn't working 100%. In terms of the IDE protocol, it's not a separate command, but is serialised as a variation of the `:type-of` command. Since the request and return are different, I'm leaning towards just treating it as a completely separate command. That makes parsing much easier. I think it also makes sense because it's exposed as a separate command in the Idris repl, :typeat rather than :t, so I think it makes sense for it to be a separate function in the client.

It doesn't exist in Idris 1, but it works in the current release version of Idris 2. That latest PR was to improve the functionality, but the command still functions on the older release version, at least for simpler cases. 