### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 ### Added
+### Changed
+### Fixed
+
+## v0.1.5
+### Added
 - Added the new Idris2-specific commands :generate-def, :generate-def-next and :proof-search-next.
 - Added a typeAt method, which implements the Idris2 :type-of + location command.
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "idris-ide-client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idris-ide-client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A library for talking to the Idris IDE.",
   "keywords": [
     "idris"


### PR DESCRIPTION
## v0.1.5
### Added
- Added the new Idris2-specific commands :generate-def, :generate-def-next and :proof-search-next.
- Added a typeAt method, which implements the Idris2 :type-of + location command.
### Changed
- The client now keeps track of the protocol version, and some requests are serialised differently depending on the version.
### Fixed
- Partially fixed a bug where the :version request didn't work with Idris2 because of a breaking change in the protocol.