### PR TITLE
Markdown

### DIFF
--- a/test/client/v2-md.test.ts
+++ b/test/client/v2-md.test.ts
@@ -34,143 +34,143 @@ describe("Running the v2 client commands on test.md", () => {
     assert.deepEqual(actual, expected.loadFile)
   }).timeout(10000)
 
-  // it("returns the expected result for :add-clause.", async () => {
-  //   const actual = await ic.addClause("f", 7)
-  //   assert.deepEqual(std(actual), expected.addClause)
-  // })
+  it("returns the expected result for :add-clause.", async () => {
+    const actual = await ic.addClause("f", 14)
+    assert.deepEqual(std(actual), expected.addClause)
+  })
 
-  // // Unimplemented
-  // // (:write-string "add-missing: command not yet implemented. Hopefully soon!" 3)
-  // // Also, how will this work if it won’t load the file with missing cases?
-  // it("returns the expected result for :add-missing.", async () => {
-  //   const actual = await ic.addMissing("getName", 9)
-  //   assert.deepEqual(std(actual), unimplemented.addMissing)
-  // })
+  // Unimplemented
+  // (:write-string "add-missing: command not yet implemented. Hopefully soon!" 3)
+  // Also, how will this work if it won’t load the file with missing cases?
+  it("returns the expected result for :add-missing.", async () => {
+    const actual = await ic.addMissing("getName", 16)
+    assert.deepEqual(std(actual), unimplemented.addMissing)
+  })
 
-  // // Unimplemented
-  // // (:write-string "apropros: command not yet implemented. Hopefully soon!" 4)
-  // it("returns the expected result for :apropos.", async () => {
-  //   const actual = await ic.apropos("plus")
-  //   assert.deepEqual(std(actual), unimplemented.apropos)
-  // })
+  // Unimplemented
+  // (:write-string "apropros: command not yet implemented. Hopefully soon!" 4)
+  it("returns the expected result for :apropos.", async () => {
+    const actual = await ic.apropos("plus")
+    assert.deepEqual(std(actual), unimplemented.apropos)
+  })
 
-  // // Unimplemented
-  // // (:write-string "browse-namespace: command not yet implemented. Hopefully soon!" 3)
-  // it("returns the expected result for :browse-namespace.", async () => {
-  //   const actual = await ic.browseNamespace("Language.Reflection")
-  //   assert.deepEqual(std(actual), unimplemented.browseNamespace)
-  // })
+  // Unimplemented
+  // (:write-string "browse-namespace: command not yet implemented. Hopefully soon!" 3)
+  it("returns the expected result for :browse-namespace.", async () => {
+    const actual = await ic.browseNamespace("Language.Reflection")
+    assert.deepEqual(std(actual), unimplemented.browseNamespace)
+  })
 
-  // // Unimplemented
-  // // (:write-string "calls-who: command not yet implemented. Hopefully soon!" 6)
-  // it("returns the expected result for :calls-who.", async () => {
-  //   const actual = await ic.callsWho("plusTwo")
-  //   assert.deepEqual(std(actual), unimplemented.callsWho)
-  // })
+  // Unimplemented
+  // (:write-string "calls-who: command not yet implemented. Hopefully soon!" 6)
+  it("returns the expected result for :calls-who.", async () => {
+    const actual = await ic.callsWho("plusTwo")
+    assert.deepEqual(std(actual), unimplemented.callsWho)
+  })
 
-  // it("returns the expected result for :case-split", async () => {
-  //   const actual = await ic.caseSplit("n", 15)
-  //   assert.deepEqual(std(actual), expected.caseSplitV2)
-  // })
+  it("returns the expected result for :case-split", async () => {
+    const actual = await ic.caseSplit("n", 26)
+    assert.deepEqual(std(actual), expected.caseSplitV2)
+  })
 
-  // // Partially Implemented — no metadata
-  // it("returns the expected result for :docs-for", async () => {
-  //   const actual = await ic.docsFor("putStrLn", ":full")
-  //   assert.deepEqual(std(actual), unimplemented.docsFor)
-  // })
+  // Partially Implemented — no metadata
+  it("returns the expected result for :docs-for", async () => {
+    const actual = await ic.docsFor("putStrLn", ":full")
+    assert.deepEqual(std(actual), unimplemented.docsFor)
+  })
 
-  // // Partially Implemented — no metadata.
-  // // (:return (:ok "4" ()) 9)
-  // // Also, no longer includes type in response, possibly intentional.
-  // it("returns the expected result for :interpret", async () => {
-  //   const actual = await ic.interpret("2 * 2")
-  //   assert.deepEqual(std(actual), unimplemented.interpret)
-  // })
+  // Partially Implemented — no metadata.
+  // (:return (:ok "4" ()) 9)
+  // Also, no longer includes type in response, possibly intentional.
+  it("returns the expected result for :interpret", async () => {
+    const actual = await ic.interpret("2 * 2")
+    assert.deepEqual(std(actual), unimplemented.interpret)
+  })
 
-  // it("returns the expected result for :make-case", async () => {
-  //   const actual = await ic.makeCase("g_rhs", 18)
-  //   assert.deepEqual(std(actual), expected.makeCaseV2)
-  // })
+  it("returns the expected result for :make-case", async () => {
+    const actual = await ic.makeCase("g_rhs", 29)
+    assert.deepEqual(std(actual), expected.makeCaseV2)
+  })
 
-  // // Partially implemented — Broken
-  // // (:return (:ok "g_rhs : Bool -> Nat -> String\ng_rhs b n") 11)
-  // it("returns the expected result for :make-lemma", async () => {
-  //   const actual = await ic.makeLemma("g_rhs", 18)
-  //   assert.deepEqual(std(actual), unimplemented.makeLemma)
-  // })
+  // Partially implemented — Broken
+  // (:return (:ok "g_rhs : Bool -> Nat -> String\ng_rhs b n") 11)
+  it("returns the expected result for :make-lemma", async () => {
+    const actual = await ic.makeLemma("g_rhs", 29)
+    assert.deepEqual(std(actual), unimplemented.makeLemma)
+  })
 
-  // it("returns the expected result for :make-with", async () => {
-  //   const actual = await ic.makeWith("g_rhs", 18)
-  //   assert.deepEqual(std(actual), expected.makeWithV2)
-  // })
+  it("returns the expected result for :make-with", async () => {
+    const actual = await ic.makeWith("g_rhs", 29)
+    assert.deepEqual(std(actual), expected.makeWithV2)
+  })
 
-  // // Partially implemented — no metadata
-  // it("returns the expected result for :metavariables", async () => {
-  //   const actual = await ic.metavariables(80)
-  //   assert.deepEqual(std(actual), unimplemented.metavariables)
-  // })
+  // Partially implemented — no metadata
+  it("returns the expected result for :metavariables", async () => {
+    const actual = await ic.metavariables(80)
+    assert.deepEqual(std(actual), unimplemented.metavariables)
+  })
 
-  // // Unimplemented
-  // //  (:write-string "print-definition: command not yet implemented. Hopefully soon!" 14)
-  // it("returns the expected result for :print-definition", async () => {
-  //   const actual = await ic.printDefinition("Bool")
-  //   assert.deepEqual(std(actual), unimplemented.printDefinition)
-  // })
+  // Unimplemented
+  //  (:write-string "print-definition: command not yet implemented. Hopefully soon!" 14)
+  it("returns the expected result for :print-definition", async () => {
+    const actual = await ic.printDefinition("Bool")
+    assert.deepEqual(std(actual), unimplemented.printDefinition)
+  })
 
-  // it("returns the expected result for :proof-search", async () => {
-  //   const actual = await ic.proofSearch("n_rhs", 21, [])
-  //   assert.deepEqual(std(actual), expected.proofSearch)
-  // })
+  it("returns the expected result for :proof-search", async () => {
+    const actual = await ic.proofSearch("n_rhs", 32, [])
+    assert.deepEqual(std(actual), expected.proofSearch)
+  })
 
-  // // Unimplemented
-  // // (:write-string "repl-completions: command not yet implemented. Hopefully soon!" 16)
-  // // (:return (:ok ()) 3)
-  // it("returns the expected result for :repl-completions", async () => {
-  //   const actual = await ic.replCompletions("get")
-  //   assert.deepEqual(std(actual), unimplemented.replCompletions)
-  // })
+  // Unimplemented
+  // (:write-string "repl-completions: command not yet implemented. Hopefully soon!" 16)
+  // (:return (:ok ()) 3)
+  it("returns the expected result for :repl-completions", async () => {
+    const actual = await ic.replCompletions("get")
+    assert.deepEqual(std(actual), unimplemented.replCompletions)
+  })
 
-  // // Partially Implemented — no metadata
-  // // (:return (:ok "Main.Cat : Type" ()) 17)
-  // it("returns the expected result for :type-of", async () => {
-  //   const actual = await ic.typeOf("Cat")
-  //   assert.deepEqual(std(actual), unimplemented.typeOf)
-  // })
+  // Partially Implemented — no metadata
+  // (:return (:ok "Main.Cat : Type" ()) 17)
+  it("returns the expected result for :type-of", async () => {
+    const actual = await ic.typeOf("Cat")
+    assert.deepEqual(std(actual), unimplemented.typeOf)
+  })
 
-  // it("returns the expected result for :version", async () => {
-  //   const actual = await ic.version()
-  //   // We don’t want to tie the test to an actual version.
-  //   assert.isTrue(actual.ok)
-  // })
+  it("returns the expected result for :version", async () => {
+    const actual = await ic.version()
+    // We don’t want to tie the test to an actual version.
+    assert.isTrue(actual.ok)
+  })
 
-  // // Unimplemented
-  // // (:write-string "who-calls: command not yet implemented. Hopefully soon!" 18)
-  // it("returns the expected result for :who-calls", async () => {
-  //   const actual = await ic.whoCalls("Cat")
-  //   assert.deepEqual(std(actual), unimplemented.whoCalls)
-  // })
+  // Unimplemented
+  // (:write-string "who-calls: command not yet implemented. Hopefully soon!" 18)
+  it("returns the expected result for :who-calls", async () => {
+    const actual = await ic.whoCalls("Cat")
+    assert.deepEqual(std(actual), unimplemented.whoCalls)
+  })
 
-  // // New V2 commands
+  // New V2 commands
 
-  // it("returns the expected result for :generate-def", async () => {
-  //   const actual = await ic.generateDef("append", 23)
-  //   assert.deepEqual(std(actual), expected.generateDef)
-  // })
+  it("returns the expected result for :generate-def", async () => {
+    const actual = await ic.generateDef("append", 34)
+    assert.deepEqual(std(actual), expected.generateDef)
+  })
 
-  // it("returns the expected result for :generate-def-next", async () => {
-  //   const actual = await ic.generateDefNext()
-  //   assert.deepEqual(std(actual), expected.generateDefNext)
-  // })
+  it("returns the expected result for :generate-def-next", async () => {
+    const actual = await ic.generateDefNext()
+    assert.deepEqual(std(actual), expected.generateDefNext)
+  })
 
-  // it("returns the expected result for :proof-search-next", async () => {
-  //   const actual = await ic.proofSearchNext()
-  //   assert.deepEqual(std(actual), expected.proofSearchNext)
-  // })
+  it("returns the expected result for :proof-search-next", async () => {
+    const actual = await ic.proofSearchNext()
+    assert.deepEqual(std(actual), expected.proofSearchNext)
+  })
 
-  // it("returns the expected result for :type-at", async () => {
-  //   const actual = await ic.typeAt("b", 18, 5)
-  //   assert.deepEqual(std(actual), expected.typeAt)
-  // })
+  it("returns the expected result for :type-at", async () => {
+    const actual = await ic.typeAt("b", 29, 5)
+    assert.deepEqual(std(actual), expected.typeAt)
+  })
 
   after(() => {
     proc.kill()

--- a/test/resources/test-v2.md
+++ b/test/resources/test-v2.md
@@ -17,7 +17,11 @@ getName : (cat: Cat) -> String
 getName Cas = "Cas"
 getName Luna = "Luna"
 getName Sherlock = "Sherlock"
+```
 
+## Section 2
+
+~~~idris2
 plusTwo : (n: Nat) -> Nat
 plusTwo n = ?plusTwo_rhs
 
@@ -29,4 +33,6 @@ num = ?n_rhs
 
 append : Vect n a -> Vect m a -> Vect (n + m) a
 
-```
+~~~
+
+The block has to include `idris` something. It can be idris, idris2, idris3 (future proofing), etc.


### PR DESCRIPTION
This one's simpler than the .lidr tests, because there's no prefix. Everything works the same as a normal .idr file. But it's just v2.