### PR TITLE
[WIP] Update idris2 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Types are great documentation, and I’ve typed all of the s-expressions that th
 ## Status
 It works with Idris 1.3.X on all OSes.
 
-It is also compatible with the most recent release of Idris 2, currently v0.4.0. This will _not_ maintain backwards compatibility with older versions of Idris 2 until it stabilises.
+It is also compatible with the most recent release of Idris 2, currently v0.5.0. This will _not_ maintain backwards compatibility with older versions of Idris 2 until it stabilises.
 
 Not all IDE commands have been completely implemented in Idris2, see the issues for their current status.
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9376bf7b34218e2a7f92af91089b0cb413a605e2",
-        "sha256": "0mr3pc6n6rflp7dxwlwf916i2w97jhlsl60i65wnmh6sf373cm7v",
+        "rev": "93ca5ab64f78ce778c0bcecf9458263f0f6289b6",
+        "sha256": "1ii3f5fbl6rinnbypypkfsp2s72dp28vgif2akq0w8v5h8szyisd",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/9376bf7b34218e2a7f92af91089b0cb413a605e2.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/93ca5ab64f78ce778c0bcecf9458263f0f6289b6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-unstable": {
@@ -29,10 +29,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9e81f7ad8795503a55e8f90836d31c04f282af8",
-        "sha256": "0wy5b50xmvnag69v28yl0qhajq43mh3ypqlz33cjy4j3c993clim",
+        "rev": "ee084c02040e864eeeb4cf4f8538d92f7c675671",
+        "sha256": "1x8amcixdaw3ryyia32pb706vzhvn5whq9n8jin0qcha5qnm1fnh",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f9e81f7ad8795503a55e8f90836d31c04f282af8.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/ee084c02040e864eeeb4cf4f8538d92f7c675671.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/src/reply.ts
+++ b/src/reply.ts
@@ -18,6 +18,7 @@ interface MetaDetails {
   name?: string
   namespace?: string
   sourceFile?: string
+  textFormatting?: string
   ttTerm?: string
   type?: string
 }

--- a/test/client/unimplemented.ts
+++ b/test/client/unimplemented.ts
@@ -31,19 +31,34 @@ export const callsWho: FinalReply.CallsWho = {
   type: ":return",
 }
 
-// Partially Implemented — no metadata
+// Partially Implemented — partial metadata
 export const docsFor: FinalReply.DocsFor = {
   docs: "Prelude.putStrLn : HasIO io => String -> io ()\n  Output a string to stdout with a trailing newline.\n  Totality: total",
-  metadata: [],
+  metadata: [
+    { length: 16, metadata: { decor: ":function" }, start: 0 },
+    { length: 5, metadata: { decor: ":type" }, start: 19 },
+    { length: 2, metadata: { decor: ":bound" }, start: 25 },
+    { length: 6, metadata: { decor: ":type" }, start: 31 },
+    { length: 2, metadata: { decor: ":bound" }, start: 41 },
+    { length: 8, metadata: { textFormatting: ":underline" }, start: 102 },
+  ],
   id: 8,
   ok: true,
   type: ":return",
 }
 
-// Partially Implemented — no metadata
+// Partially Implemented — partial metadata
 export const interpret: FinalReply.Interpret = {
   result: "4",
-  metadata: [],
+  metadata: [
+    {
+      length: 1,
+      metadata: {
+        decor: ":data",
+      },
+      start: 0,
+    },
+  ],
   id: 8,
   ok: true,
   type: ":return",
@@ -140,9 +155,25 @@ export const replCompletions: FinalReply.ReplCompletions = {
   type: ":return",
 }
 
+// Partially implemented — partial metadata
 export const typeOf: FinalReply.TypeOf = {
   typeOf: "Main.Cat : Type",
-  metadata: [],
+  metadata: [
+    {
+      length: 8,
+      metadata: {
+        decor: ":type",
+      },
+      start: 0,
+    },
+    {
+      length: 4,
+      metadata: {
+        decor: ":type",
+      },
+      start: 11,
+    },
+  ],
   id: 8,
   ok: true,
   type: ":return",


### PR DESCRIPTION
0.5.0 brings in some partial metadata to a few of the commands, but it has also broken the `:metavariables` command. That has been [reverted](https://github.com/idris-lang/Idris2/pull/1973), and it's working fine if I build from main, but I might want to put it a workaround for 0.5.0 for now.