### PR TITLE
Idris 2 0.6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: cachix/install-nix-action@v12
-      - uses: cachix/cachix-action@v8
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v18
+      - uses: cachix/cachix-action@v12
         with:
           name: idris-ide-client
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Added
 ### Changed
+- Added workarounds to the reply-parser to handle Idris 2, version 0.6.0.
 ### Fixed
 
 ## v0.1.5

--- a/src/parser/reply-parser.ts
+++ b/src/parser/reply-parser.ts
@@ -270,7 +270,7 @@ const intoFinalReplyApropos = (
     const [_ok, apropos, metadata] = payload
     return {
       docs: apropos,
-      metadata: intoMessageMetadata(metadata),
+      metadata: metadata ? intoMessageMetadata(metadata) : [],
       id,
       ok: true,
       type: ":return",
@@ -555,7 +555,7 @@ const intoFinalReplyPrintDefinition = (
     return {
       definition,
       id,
-      metadata: intoMessageMetadata(metadata),
+      metadata: metadata ? intoMessageMetadata(metadata) : [],
       ok: true,
       type: ":return",
     }

--- a/src/reply.ts
+++ b/src/reply.ts
@@ -18,6 +18,7 @@ interface MetaDetails {
   name?: string
   namespace?: string
   sourceFile?: string
+  textFormatting?: string
   ttTerm?: string
   type?: string
 }
@@ -122,7 +123,7 @@ export namespace FinalReply {
   type AproposOk = {
     docs: string
     id: number
-    metadata: Array<MessageMetadata>
+    metadata: Array<MessageMetadata> | undefined
     ok: true
     type: ":return"
   }
@@ -260,7 +261,7 @@ export namespace FinalReply {
   type PrintDefinitionOk = {
     definition: string
     id: number
-    metadata: Array<MessageMetadata>
+    metadata: Array<MessageMetadata> | undefined
     ok: true
     type: ":return"
   }

--- a/test/client/unimplemented.ts
+++ b/test/client/unimplemented.ts
@@ -31,24 +31,6 @@ export const callsWho: FinalReply.CallsWho = {
   type: ":return",
 }
 
-// Partially Implemented — no metadata
-export const docsFor: FinalReply.DocsFor = {
-  docs: "Prelude.putStrLn : HasIO io => String -> io ()\n  Output a string to stdout with a trailing newline.\n  Totality: total",
-  metadata: [],
-  id: 8,
-  ok: true,
-  type: ":return",
-}
-
-// Partially Implemented — no metadata
-export const interpret: FinalReply.Interpret = {
-  result: "4",
-  metadata: [],
-  id: 8,
-  ok: true,
-  type: ":return",
-}
-
 // Partially Implemented — kinda broken
 export const makeLemma: FinalReply.MakeLemmaOk = {
   declaration: "g_rhs : Bool -> Nat -> String",
@@ -63,7 +45,7 @@ export const metavariables: FinalReply.Metavariables = {
     {
       metavariable: {
         metadata: [],
-        name: "Main.append",
+        name: `"Main.append"`,
         type: "Vect n a -> Vect m a -> Vect (plus n m) a",
       },
       premises: [],
@@ -71,7 +53,7 @@ export const metavariables: FinalReply.Metavariables = {
     {
       metavariable: {
         metadata: [],
-        name: "Main.f",
+        name: `"Main.f"`,
         type: "Cat -> String",
       },
       premises: [],
@@ -79,7 +61,7 @@ export const metavariables: FinalReply.Metavariables = {
     {
       metavariable: {
         metadata: [],
-        name: "Main.g_rhs",
+        name: `"Main.g_rhs"`,
         type: "String",
       },
       premises: [
@@ -98,7 +80,7 @@ export const metavariables: FinalReply.Metavariables = {
     {
       metavariable: {
         metadata: [],
-        name: "Main.n_rhs",
+        name: `"Main.n_rhs"`,
         type: "Nat",
       },
       premises: [],
@@ -108,7 +90,7 @@ export const metavariables: FinalReply.Metavariables = {
     {
       metavariable: {
         metadata: [],
-        name: "Main.plusTwo_rhs",
+        name: `"Main.plusTwo_rhs"`,
         type: "Nat",
       },
       premises: [
@@ -127,21 +109,6 @@ export const metavariables: FinalReply.Metavariables = {
 
 export const printDefinition: FinalReply.PrintDefinition = {
   definition: "Bool",
-  metadata: [],
-  id: 8,
-  ok: true,
-  type: ":return",
-}
-
-export const replCompletions: FinalReply.ReplCompletions = {
-  completions: [],
-  id: 8,
-  ok: true,
-  type: ":return",
-}
-
-export const typeOf: FinalReply.TypeOf = {
-  typeOf: "Main.Cat : Type",
   metadata: [],
   id: 8,
   ok: true,

--- a/test/client/v1-client.test.ts
+++ b/test/client/v1-client.test.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai"
 import { spawn, ChildProcess } from "child_process"
-import * as expected from "./expected"
+import * as expected from "./v1-expected"
 import { clean, omitKeys } from "../utils"
 import { IdrisClient } from "../../src/client"
 

--- a/test/client/v1-expected.ts
+++ b/test/client/v1-expected.ts
@@ -598,6 +598,17 @@ export const replCompletions: FinalReply.ReplCompletions = {
   type: ":return",
 }
 
+export const replCompletionsV2 : FinalReply.ReplCompletions = {
+  completions: [
+    "getName",
+    "getAt",
+    "getLine", "getChar", "getRight", "getLeft"
+  ],
+  id: 8,
+  ok: true,
+  type: ":return",
+}
+
 export const typeOf: FinalReply.TypeOf = {
   typeOf: "Cat : Type",
   metadata: [
@@ -623,6 +634,29 @@ export const typeOf: FinalReply.TypeOf = {
         type: "Type",
       },
       start: 6,
+    },
+  ],
+  id: 8,
+  ok: true,
+  type: ":return",
+}
+
+export const typeOfV2: FinalReply.TypeOf = {
+  typeOf: "Main.Cat : Type",
+  metadata: [
+    {
+      length: 8,
+      metadata: {
+        decor: ":type",
+      },
+      start: 0,
+    },
+    {
+      length: 4,
+      metadata: {
+        decor: ":type",
+      },
+      start: 11,
     },
   ],
   id: 8,

--- a/test/client/v1-lidr.test.ts
+++ b/test/client/v1-lidr.test.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai"
 import { spawn, ChildProcess } from "child_process"
 
-import * as expected from "./expected"
+import * as expected from "./v1-expected"
 import * as unimplemented from "./unimplemented"
 import { clean, omitKeys } from "../utils"
 import { IdrisClient } from "../../src/client"

--- a/test/client/v2-client.test.ts
+++ b/test/client/v2-client.test.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai"
 import { spawn, ChildProcess } from "child_process"
-import * as expected from "./expected"
+import * as expected from "./v2-expected"
 import * as unimplemented from "./unimplemented"
 import { clean, omitKeys } from "../utils"
 import { IdrisClient } from "../../src/client"
@@ -70,26 +70,23 @@ describe("Running the v2 client commands on test.idr", () => {
 
   it("returns the expected result for :case-split", async () => {
     const actual = await ic.caseSplit("n", 15)
-    assert.deepEqual(std(actual), expected.caseSplitV2)
+    assert.deepEqual(std(actual), expected.caseSplit)
   })
 
-  // Partially Implemented — no metadata
   it("returns the expected result for :docs-for", async () => {
     const actual = await ic.docsFor("putStrLn", ":full")
-    assert.deepEqual(std(actual), unimplemented.docsFor)
+    assert.deepEqual(std(actual), expected.docsFor)
   })
 
-  // Partially Implemented — no metadata.
-  // (:return (:ok "4" ()) 9)
-  // Also, no longer includes type in response, possibly intentional.
+  // No longer includes type in response, possibly intentional.
   it("returns the expected result for :interpret", async () => {
     const actual = await ic.interpret("2 * 2")
-    assert.deepEqual(std(actual), unimplemented.interpret)
+    assert.deepEqual(std(actual), expected.interpret)
   })
 
   it("returns the expected result for :make-case", async () => {
     const actual = await ic.makeCase("g_rhs", 18)
-    assert.deepEqual(std(actual), expected.makeCaseV2)
+    assert.deepEqual(std(actual), expected.makeCase)
   })
 
   // Partially implemented — Broken
@@ -101,7 +98,7 @@ describe("Running the v2 client commands on test.idr", () => {
 
   it("returns the expected result for :make-with", async () => {
     const actual = await ic.makeWith("g_rhs", 18)
-    assert.deepEqual(std(actual), expected.makeWithV2)
+    assert.deepEqual(std(actual), expected.makeWith)
   })
 
   // Partially implemented — no metadata
@@ -127,14 +124,12 @@ describe("Running the v2 client commands on test.idr", () => {
   // (:return (:ok ()) 3)
   it("returns the expected result for :repl-completions", async () => {
     const actual = await ic.replCompletions("get")
-    assert.deepEqual(std(actual), unimplemented.replCompletions)
+    assert.deepEqual(std(actual), expected.replCompletions)
   })
 
-  // Partially Implemented — no metadata
-  // (:return (:ok "Main.Cat : Type" ()) 17)
   it("returns the expected result for :type-of", async () => {
     const actual = await ic.typeOf("Cat")
-    assert.deepEqual(std(actual), unimplemented.typeOf)
+    assert.deepEqual(std(actual), expected.typeOf)
   })
 
   it("returns the expected result for :version", async () => {

--- a/test/client/v2-expected.ts
+++ b/test/client/v2-expected.ts
@@ -1,0 +1,197 @@
+import * as v1 from "./v1-expected"
+import { FinalReply } from "../../src/reply"
+
+/**
+ * The expected replies are extracted into a separate file because I want to reuse
+ * them across the V1 and V2 tests. That makes it easier to determine where V2
+ * is not backwards compatible, or has bugs.
+ *
+ * The ttTerm key has been omitted, since it’s random, and we can’t check it for equality.
+ */
+
+export const loadFile: FinalReply.LoadFile = v1.loadFile
+
+export const addClause: FinalReply.AddClauseOk = v1.addClause
+
+export const caseSplit: FinalReply.CaseSplitOk = {
+  caseClause: "plusTwo 0 = ?plusTwo_rhs_0\nplusTwo (S k) = ?plusTwo_rhs_1",
+  id: 8,
+  ok: true,
+  type: ":return",
+}
+
+export const docsFor: FinalReply.DocsFor = {
+  docs: "Prelude.putStrLn : HasIO io => String -> io ()\n  Output a string to stdout with a trailing newline.\n  Totality: total\n  Visibility: export",
+  metadata: [
+    {
+      length: 16,
+      metadata: {
+        decor: ":function",
+      },
+      start: 0,
+    },
+    {
+      length: 5,
+      metadata: {
+        decor: ":type",
+      },
+      start: 19,
+    },
+    {
+      length: 2,
+      metadata: {
+        decor: ":bound",
+      },
+      start: 25,
+    },
+    {
+      length: 2,
+      metadata: {
+        decor: ":keyword",
+      },
+      start: 28,
+    },
+    {
+      length: 6,
+      metadata: {
+        decor: ":type",
+      },
+      start: 31,
+    },
+    {
+      length: 2,
+      metadata: {
+        decor: ":keyword",
+      },
+      start: 38,
+    },
+    {
+      length: 2,
+      metadata: {
+        decor: ":bound",
+      },
+      start: 41,
+    },
+    {
+      length: 8,
+      metadata: {
+        textFormatting: ":underline",
+      },
+      start: 102,
+    },
+    {
+      length: 5,
+      metadata: {
+        decor: ":keyword",
+      },
+      start: 112,
+    },
+    {
+      length: 10,
+      metadata: {
+        textFormatting: ":underline",
+      },
+      start: 120,
+    },
+    {
+      length: 6,
+      metadata: {
+        decor: ":keyword",
+      },
+      start: 132,
+    },
+  ],
+  id: 8,
+  ok: true,
+  type: ":return",
+}
+
+export const interpret: FinalReply.Interpret = {
+  result: "4",
+  metadata: [{ length: 1, metadata: { decor: ":data" }, start: 0 }],
+  id: 8,
+  ok: true,
+  type: ":return",
+}
+
+export const makeCase: FinalReply.MakeCase = {
+  caseClause: "g n b = case _ of\n             case_val => ?g_rhs",
+  id: 8,
+  ok: true,
+  type: ":return",
+}
+
+export const makeWith: FinalReply.MakeWith = {
+  id: 8,
+  ok: true,
+  type: ":return",
+  withClause: "g n b with (_)\n  g n b | with_pat = ?g_rhs_rhs",
+}
+
+export const proofSearch: FinalReply.ProofSearch = v1.proofSearch
+
+export const replCompletions: FinalReply.ReplCompletions = {
+  completions: [
+    "getName",
+    "getAt",
+    "getLine",
+    "getChar",
+    "getRight",
+    "getLeft",
+  ],
+  id: 8,
+  ok: true,
+  type: ":return",
+}
+
+export const typeOf: FinalReply.TypeOf = {
+  typeOf: "Main.Cat : Type",
+  metadata: [
+    {
+      length: 8,
+      metadata: {
+        decor: ":type",
+      },
+      start: 0,
+    },
+    {
+      length: 4,
+      metadata: {
+        decor: ":type",
+      },
+      start: 11,
+    },
+  ],
+  id: 8,
+  ok: true,
+  type: ":return",
+}
+
+// Idris 2 only.
+export const generateDef: FinalReply.GenerateDefOk = {
+  def: "append [] ys = ys\nappend (x :: xs) ys = x :: append xs ys",
+  id: 8,
+  ok: true,
+  type: ":return",
+}
+
+export const generateDefNext: FinalReply.GenerateDefOk = {
+  def: "append [] ys = ys\nappend (x :: xs) [] = x :: append xs []\nappend (x :: xs) (y :: ys) = x :: append xs (y :: ys)",
+  id: 8,
+  ok: true,
+  type: ":return",
+}
+
+export const proofSearchNext: FinalReply.ProofSearch = {
+  id: 8,
+  ok: true,
+  solution: "1",
+  type: ":return",
+}
+
+export const typeAt: FinalReply.TypeAt = {
+  id: 8,
+  ok: true,
+  type: ":return",
+  typeAt: "b : Bool",
+}

--- a/test/client/v2-lidr.test.ts
+++ b/test/client/v2-lidr.test.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai"
 import { spawn, ChildProcess } from "child_process"
-import * as expected from "./expected"
+import * as expected from "./v2-expected"
 import * as unimplemented from "./unimplemented"
 import { clean, omitKeys } from "../utils"
 import { IdrisClient } from "../../src/client"
@@ -88,12 +88,12 @@ describe("Running the v2 client commands on test.lidr", () => {
 
   it("returns the expected result for :case-split", async () => {
     const actual = await ic.caseSplit("n", 21)
-    const correctlyPrefixed = expected.caseSplitV2.caseClause
+    const correctlyPrefixed = expected.caseSplit.caseClause
       .split("\n")
       .map((line) => codePrefix + line)
       .join("\n")
     assert.deepEqual(std(actual), {
-      ...expected.caseSplitV2,
+      ...expected.caseSplit,
       caseClause: correctlyPrefixed,
     })
   })
@@ -101,7 +101,7 @@ describe("Running the v2 client commands on test.lidr", () => {
   // Partially Implemented — no metadata
   it("returns the expected result for :docs-for", async () => {
     const actual = await ic.docsFor("putStrLn", ":full")
-    assert.deepEqual(std(actual), unimplemented.docsFor)
+    assert.deepEqual(std(actual), expected.docsFor)
   })
 
   // Partially Implemented — no metadata.
@@ -109,7 +109,7 @@ describe("Running the v2 client commands on test.lidr", () => {
   // Also, no longer includes type in response, possibly intentional.
   it("returns the expected result for :interpret", async () => {
     const actual = await ic.interpret("2 * 2")
-    assert.deepEqual(std(actual), unimplemented.interpret)
+    assert.deepEqual(std(actual), expected.interpret)
   })
 
   it("returns the expected result for :make-case", async () => {
@@ -119,12 +119,12 @@ describe("Running the v2 client commands on test.lidr", () => {
     // prefixed though, and indented correctly.
     // > > g n b = case _ of
     // >                case_val => ?g_rhs
-    const incorrectlyPrefixed = expected.makeCaseV2.caseClause
+    const incorrectlyPrefixed = expected.makeCase.caseClause
       .split("\n")
       .map((line, idx) => (idx === 0 ? "> > " + line : ">   " + line))
       .join("\n")
     assert.deepEqual(std(actual), {
-      ...expected.makeCaseV2,
+      ...expected.makeCase,
       caseClause: incorrectlyPrefixed,
     })
   })
@@ -151,14 +151,14 @@ describe("Running the v2 client commands on test.lidr", () => {
     // to:
     // > > > g n b with (_)
     // > >   > g n b | with_pat = ?g_rhs_rhs
-    const incorrectlyPrefixed = expected.makeWithV2.withClause
+    const incorrectlyPrefixed = expected.makeWith.withClause
       .split("\n")
       .map((line, idx) =>
         idx === 0 ? "> > > " + line : "> >   > " + line.trim()
       )
       .join("\n")
     assert.deepEqual(std(actual), {
-      ...expected.makeWithV2,
+      ...expected.makeWith,
       withClause: incorrectlyPrefixed,
     })
   })
@@ -186,14 +186,14 @@ describe("Running the v2 client commands on test.lidr", () => {
   // (:return (:ok ()) 3)
   it("returns the expected result for :repl-completions", async () => {
     const actual = await ic.replCompletions("get")
-    assert.deepEqual(std(actual), unimplemented.replCompletions)
+    assert.deepEqual(std(actual), expected.replCompletions)
   })
 
   // Partially Implemented — no metadata
   // (:return (:ok "Main.Cat : Type" ()) 17)
   it("returns the expected result for :type-of", async () => {
     const actual = await ic.typeOf("Cat")
-    assert.deepEqual(std(actual), unimplemented.typeOf)
+    assert.deepEqual(std(actual), expected.typeOf)
   })
 
   it("returns the expected result for :version", async () => {

--- a/test/client/v2-md.test.ts
+++ b/test/client/v2-md.test.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai"
 import { spawn, ChildProcess } from "child_process"
-import * as expected from "./expected"
+import * as expected from "./v2-expected"
 import * as unimplemented from "./unimplemented"
 import { clean, omitKeys } from "../utils"
 import { IdrisClient } from "../../src/client"
@@ -70,26 +70,18 @@ describe("Running the v2 client commands on test.md", () => {
 
   it("returns the expected result for :case-split", async () => {
     const actual = await ic.caseSplit("n", 26)
-    assert.deepEqual(std(actual), expected.caseSplitV2)
+    assert.deepEqual(std(actual), expected.caseSplit)
   })
 
   // Partially Implemented — no metadata
   it("returns the expected result for :docs-for", async () => {
     const actual = await ic.docsFor("putStrLn", ":full")
-    assert.deepEqual(std(actual), unimplemented.docsFor)
-  })
-
-  // Partially Implemented — no metadata.
-  // (:return (:ok "4" ()) 9)
-  // Also, no longer includes type in response, possibly intentional.
-  it("returns the expected result for :interpret", async () => {
-    const actual = await ic.interpret("2 * 2")
-    assert.deepEqual(std(actual), unimplemented.interpret)
+    assert.deepEqual(std(actual), expected.docsFor)
   })
 
   it("returns the expected result for :make-case", async () => {
     const actual = await ic.makeCase("g_rhs", 29)
-    assert.deepEqual(std(actual), expected.makeCaseV2)
+    assert.deepEqual(std(actual), expected.makeCase)
   })
 
   // Partially implemented — Broken
@@ -101,7 +93,7 @@ describe("Running the v2 client commands on test.md", () => {
 
   it("returns the expected result for :make-with", async () => {
     const actual = await ic.makeWith("g_rhs", 29)
-    assert.deepEqual(std(actual), expected.makeWithV2)
+    assert.deepEqual(std(actual), expected.makeWith)
   })
 
   // Partially implemented — no metadata
@@ -127,14 +119,7 @@ describe("Running the v2 client commands on test.md", () => {
   // (:return (:ok ()) 3)
   it("returns the expected result for :repl-completions", async () => {
     const actual = await ic.replCompletions("get")
-    assert.deepEqual(std(actual), unimplemented.replCompletions)
-  })
-
-  // Partially Implemented — no metadata
-  // (:return (:ok "Main.Cat : Type" ()) 17)
-  it("returns the expected result for :type-of", async () => {
-    const actual = await ic.typeOf("Cat")
-    assert.deepEqual(std(actual), unimplemented.typeOf)
+    assert.deepEqual(std(actual), expected.replCompletions)
   })
 
   it("returns the expected result for :version", async () => {


### PR DESCRIPTION
The important changes here are the workaround for the still empty responses for :apropos and :print-definition. I believe they used to have an empty metavariables list, which is now absent, and was causing parse errors. They're still not implemented, but now the parser won't complain about them. 

I've also updated the tests, because some more commands are returning (at least some) metadata. And :repl-completions is working now.